### PR TITLE
Introduce abstract pruning base class

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,3 +1,3 @@
+from .base_pipeline import BasePruningPipeline
 from .pruning_pipeline import PruningPipeline
-
-__all__ = ["PruningPipeline"]
+__all__ = ["BasePruningPipeline", "PruningPipeline"]

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -1,22 +1,17 @@
-from pathlib import Path
 from typing import Any, Dict
+
+from .base_pipeline import BasePruningPipeline
 
 from ultralytics_pruning import YOLO
 from ultralytics_pruning.utils.torch_utils import get_flops, get_num_params
 
 
-class PruningPipeline:
+class PruningPipeline(BasePruningPipeline):
     """High level pipeline to orchestrate pruning of YOLO models."""
 
     def __init__(self, model_path: str, data: str, workdir: str = "runs/pruning") -> None:
-        self.model_path = model_path
-        self.data = data
-        self.workdir = Path(workdir)
-        self.workdir.mkdir(parents=True, exist_ok=True)
+        super().__init__(model_path, data, workdir)
         self.model: YOLO | None = None
-        self.initial_stats: Dict[str, float] = {}
-        self.pruned_stats: Dict[str, float] = {}
-        self.metrics: Dict[str, Any] = {}
 
     def load_model(self) -> None:
         """Load the YOLO model from ``self.model_path``."""


### PR DESCRIPTION
## Summary
- define `BasePruningPipeline` with abstract methods
- extend `PruningPipeline` from the base class
- export both classes from the package

## Testing
- `python -m py_compile pipeline/base_pipeline.py pipeline/pruning_pipeline.py`
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'ultralytics')*

------
https://chatgpt.com/codex/tasks/task_b_6849ec492d448324b3ec0bc93ca4ce5e