### PR TITLE
Add pruning method abstractions

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from typing import Any, Dict
 
 from .base_pipeline import BasePruningPipeline
+from prune_methods.base import BasePruningMethod
 
 from ultralytics_pruning import YOLO
 from ultralytics_pruning.utils.torch_utils import get_flops, get_num_params
@@ -9,8 +12,14 @@ from ultralytics_pruning.utils.torch_utils import get_flops, get_num_params
 class PruningPipeline(BasePruningPipeline):
     """High level pipeline to orchestrate pruning of YOLO models."""
 
-    def __init__(self, model_path: str, data: str, workdir: str = "runs/pruning") -> None:
-        super().__init__(model_path, data, workdir)
+    def __init__(
+        self,
+        model_path: str,
+        data: str,
+        workdir: str = "runs/pruning",
+        pruning_method: BasePruningMethod | None = None,
+    ) -> None:
+        super().__init__(model_path, data, workdir, pruning_method)
         self.model: YOLO | None = None
 
     def load_model(self) -> None:
@@ -36,23 +45,26 @@ class PruningPipeline(BasePruningPipeline):
 
     def analyze_structure(self) -> None:
         """Analyze model structure to guide pruning."""
-        # Placeholder for user provided analysis logic
-        raise NotImplementedError
+        if self.pruning_method is None:
+            raise NotImplementedError
+        self.pruning_method.analyze_model()
 
     def generate_pruning_mask(self, ratio: float) -> None:
         """Generate pruning mask at ``ratio`` sparsity."""
-        # Placeholder for mask generation logic
-        raise NotImplementedError
+        if self.pruning_method is None:
+            raise NotImplementedError
+        self.pruning_method.generate_pruning_mask(ratio)
 
     def apply_pruning(self) -> None:
         """Apply the previously generated pruning mask to the model."""
-        # Placeholder for pruning application logic
-        raise NotImplementedError
+        if self.pruning_method is None:
+            raise NotImplementedError
+        self.pruning_method.apply_pruning()
 
     def reconfigure_model(self) -> None:
         """Reconfigure the model after pruning if necessary."""
-        # Optional step for layer reconfiguration
-        raise NotImplementedError
+        if self.pruning_method is None:
+            raise NotImplementedError
 
     def calc_pruned_stats(self) -> Dict[str, float]:
         """Calculate parameter count and FLOPs after pruning."""

--- a/prune_methods/__init__.py
+++ b/prune_methods/__init__.py
@@ -1,0 +1,25 @@
+"""Pruning method interfaces and placeholders."""
+
+from .base import BasePruningMethod
+from .methods import (
+    Method1,
+    Method2,
+    Method3,
+    Method4,
+    Method5,
+    Method6,
+    Method7,
+    Method8,
+)
+
+__all__ = [
+    "BasePruningMethod",
+    "Method1",
+    "Method2",
+    "Method3",
+    "Method4",
+    "Method5",
+    "Method6",
+    "Method7",
+    "Method8",
+]

--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -1,0 +1,72 @@
+"""Base classes for model pruning methods.
+
+This module defines an abstract :class:`BasePruningMethod` that encapsulates the
+common interface used by all pruning algorithms.  Individual pruning strategies
+should subclass :class:`BasePruningMethod` and implement the analysis,
+mask generation and pruning application steps.
+
+Additionally utility hooks for visualising and storing pruning results are
+provided.  The default implementations only act as placeholders and should be
+extended by concrete subclasses.
+"""
+
+from __future__ import annotations
+
+import abc
+from pathlib import Path
+from typing import Any, Dict
+
+
+class BasePruningMethod(abc.ABC):
+    """Abstract interface for pruning algorithms."""
+
+    def __init__(self, model: Any, workdir: str | Path = "runs/pruning") -> None:
+        self.model = model
+        self.workdir = Path(workdir)
+        self.workdir.mkdir(parents=True, exist_ok=True)
+        self.initial_stats: Dict[str, float] = {}
+        self.pruned_stats: Dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    # Core pruning steps to be implemented by subclasses
+    # ------------------------------------------------------------------
+    @abc.abstractmethod
+    def analyze_model(self) -> None:
+        """Inspect model structure and gather information for pruning."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def generate_pruning_mask(self, ratio: float) -> None:
+        """Create a pruning mask with the given sparsity ``ratio``."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def apply_pruning(self) -> None:
+        """Apply the previously generated pruning mask to ``self.model``."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Utility hooks
+    # ------------------------------------------------------------------
+    def visualize_comparison(self) -> None:
+        """Visualize baseline vs pruned metrics.
+
+        Implementations should compare FLOPs, parameter count, number of
+        filters and file size between the unpruned and pruned models.  The
+        default implementation is empty.
+        """
+
+        pass
+
+    def visualize_pruned_filters(self) -> None:
+        """Visualize which filters were removed by pruning."""
+        pass
+
+    def save_results(self, path: str | Path) -> None:
+        """Persist pruning results to ``path``.
+
+        Subclasses may store masks, statistics or other artefacts useful for
+        reproducing the pruning procedure.
+        """
+
+        pass

--- a/prune_methods/methods.py
+++ b/prune_methods/methods.py
@@ -1,0 +1,116 @@
+"""Placeholder implementations for various pruning strategies.
+
+This module defines a set of stub classes representing different pruning
+methods.  Each class inherits from :class:`BasePruningMethod` and only provides
+empty implementations of the required abstract methods.  Concrete logic will be
+added later.
+"""
+
+from __future__ import annotations
+
+
+from .base import BasePruningMethod
+
+
+class Method1(BasePruningMethod):
+    """Stub pruning method #1."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method2(BasePruningMethod):
+    """Stub pruning method #2."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method3(BasePruningMethod):
+    """Stub pruning method #3."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method4(BasePruningMethod):
+    """Stub pruning method #4."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method5(BasePruningMethod):
+    """Stub pruning method #5."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method6(BasePruningMethod):
+    """Stub pruning method #6."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method7(BasePruningMethod):
+    """Stub pruning method #7."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass
+
+
+class Method8(BasePruningMethod):
+    """Stub pruning method #8."""
+
+    def analyze_model(self) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
+        pass
+
+    def apply_pruning(self) -> None:  # pragma: no cover
+        pass


### PR DESCRIPTION
## Summary
- add `prune_methods` package with base abstract class and method stubs
- expose placeholders via `prune_methods.__init__`
- integrate optional pruning methods with `BasePruningPipeline`
- allow `PruningPipeline` to delegate pruning steps to a method instance

## Testing
- `python -m py_compile pipeline/base_pipeline.py pipeline/pruning_pipeline.py prune_methods/*.py`

------
https://chatgpt.com/codex/tasks/task_b_6849f0e4a8448324974f6796b22f2433