### PR TITLE
Add helper utilities for pruning framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,18 @@ nc: 80  # number of classes
 
 See the `ultralytics_pruning/cfg/datasets` directory for examples.
 
+## Helper utilities
+
+The ``helper`` package bundles small components used across the pruning
+pipeline:
+
+* ``ExperimentManager`` – records results for multiple pruning runs and
+  visualises comparisons.
+* ``MetricManager`` – collects training, computation and pruning metrics in a
+  structured format.
+* ``Logger`` – lightweight wrapper around :mod:`logging` used throughout the
+  pipeline and pruning methods.
+
+These utilities follow SOLID design principles to keep the codebase easy to
+maintain.
+

--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -1,0 +1,7 @@
+"""Helper utilities for pruning experiments."""
+
+from .logger import Logger, get_logger
+from .metric_manager import MetricManager
+from .experiment_manager import ExperimentManager
+
+__all__ = ["Logger", "get_logger", "MetricManager", "ExperimentManager"]

--- a/helper/experiment_manager.py
+++ b/helper/experiment_manager.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Utilities to manage pruning experiments."""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import matplotlib.pyplot as plt
+
+
+class ExperimentManager:
+    """Manage multiple pruning experiments and produce comparisons."""
+
+    def __init__(self, backbone: str, workdir: str = "runs/experiments") -> None:
+        self.backbone = backbone
+        self.workdir = Path(workdir)
+        self.workdir.mkdir(parents=True, exist_ok=True)
+        self.results: List[Dict[str, Any]] = []
+
+    def add_result(self, method: str, ratio: float, metrics: Dict[str, Any]) -> None:
+        """Record the metrics for a pruning experiment."""
+        self.results.append({"method": method, "ratio": ratio, "metrics": metrics})
+
+    def compare_pruning_methods(self) -> None:
+        """Visualize mAP against pruning ratio for all experiments."""
+        if not self.results:
+            return
+        ratios = [r["ratio"] for r in self.results]
+        maps = [r["metrics"].get("mAP", 0) for r in self.results]
+        labels = [r["method"] for r in self.results]
+        plt.figure()
+        plt.title("Pruning Comparison")
+        plt.xlabel("Pruning ratio")
+        plt.ylabel("mAP")
+        plt.plot(ratios, maps, marker="o")
+        for x, y, lbl in zip(ratios, maps, labels):
+            plt.text(x, y, lbl)
+        plt.tight_layout()
+        plt.savefig(self.workdir / "comparison.png")
+        plt.close()

--- a/helper/logger.py
+++ b/helper/logger.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Central logging utilities for the pruning pipeline."""
+
+import logging
+from typing import Optional
+
+
+class Logger:
+    """Simple wrapper around :mod:`logging` providing a shared logger."""
+
+    def __init__(self, name: str = "pruning") -> None:
+        self.logger = logging.getLogger(name)
+        self.logger.setLevel(logging.INFO)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+    def info(self, msg: str, *args, **kwargs) -> None:
+        self.logger.info(msg, *args, **kwargs)
+
+    def warning(self, msg: str, *args, **kwargs) -> None:
+        self.logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg: str, *args, **kwargs) -> None:
+        self.logger.error(msg, *args, **kwargs)
+
+    def debug(self, msg: str, *args, **kwargs) -> None:
+        self.logger.debug(msg, *args, **kwargs)
+
+    def set_level(self, level: int) -> None:
+        self.logger.setLevel(level)
+
+
+def get_logger(name: str = "pruning", level: int = logging.INFO) -> Logger:
+    """Return a :class:`Logger` configured with ``name`` and ``level``."""
+    log = Logger(name)
+    log.set_level(level)
+    return log

--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Metric recording utilities for pruning experiments."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+TRAINING_METRIC_FIELDS = [
+    "mAP",
+    "precision",
+    "recall",
+    "box_loss",
+    "seg_loss",
+    "objectness_loss",
+    "cls_loss",
+]
+
+COMPUTATION_METRIC_FIELDS = [
+    "elapsed_seconds",
+    "total_time",
+    "total_time_minutes",
+    "gpu_utilization",
+    "gpu_memory_used_mb",
+    "gpu_memory_total_mb",
+    "ram_used_mb",
+    "ram_total_mb",
+    "ram_percent",
+    "power_usage_watts",
+]
+
+PRUNING_METRIC_FIELDS = {
+    "parameters": ["original", "pruned", "reduction", "reduction_percent"],
+    "flops": ["original", "pruned", "reduction", "reduction_percent"],
+    "filters": ["original", "pruned", "reduction", "reduction_percent"],
+    "compression_ratio": None,
+}
+
+
+@dataclass
+class MetricManager:
+    """Accumulate training, computation and pruning metrics."""
+
+    training: Dict[str, Any] = field(default_factory=dict)
+    computation: Dict[str, Any] = field(default_factory=dict)
+    pruning: Dict[str, Any] = field(default_factory=dict)
+
+    def record_training(self, metrics: Dict[str, Any]) -> None:
+        """Store training metrics filtered by :data:`TRAINING_METRIC_FIELDS`."""
+        for field in TRAINING_METRIC_FIELDS:
+            if field in metrics:
+                self.training[field] = metrics[field]
+
+    def record_computation(self, metrics: Dict[str, Any]) -> None:
+        """Store computation metrics filtered by :data:`COMPUTATION_METRIC_FIELDS`."""
+        for field in COMPUTATION_METRIC_FIELDS:
+            if field in metrics:
+                self.computation[field] = metrics[field]
+
+    def record_pruning(self, metrics: Dict[str, Any]) -> None:
+        """Store pruning metrics according to :data:`PRUNING_METRIC_FIELDS`."""
+        for key, subfields in PRUNING_METRIC_FIELDS.items():
+            if subfields is None and key in metrics:
+                self.pruning[key] = metrics[key]
+            elif key in metrics and isinstance(metrics[key], dict):
+                self.pruning.setdefault(key, {})
+                for sub in subfields or []:
+                    if sub in metrics[key]:
+                        self.pruning[key][sub] = metrics[key][sub]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return all recorded metrics as a dictionary."""
+        return {
+            "training": self.training,
+            "computation": self.computation,
+            "pruning": self.pruning,
+        }

--- a/pipeline/base_pipeline.py
+++ b/pipeline/base_pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from prune_methods.base import BasePruningMethod
+from helper import get_logger, Logger
 
 
 class BasePruningPipeline(abc.ABC):
@@ -22,6 +23,7 @@ class BasePruningPipeline(abc.ABC):
         data: str,
         workdir: str = "runs/pruning",
         pruning_method: BasePruningMethod | None = None,
+        logger: Logger | None = None,
     ) -> None:
         self.model_path = model_path
         self.data = data
@@ -29,12 +31,14 @@ class BasePruningPipeline(abc.ABC):
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.model = None
         self.pruning_method = pruning_method
+        self.logger = logger or get_logger()
         self.initial_stats: Dict[str, float] = {}
         self.pruned_stats: Dict[str, float] = {}
         self.metrics: Dict[str, Any] = {}
 
     def set_pruning_method(self, method: BasePruningMethod) -> None:
         """Attach a :class:`BasePruningMethod` instance to the pipeline."""
+        self.logger.info("Setting pruning method: %s", method.__class__.__name__)
         self.pruning_method = method
 
     @abc.abstractmethod
@@ -87,11 +91,13 @@ class BasePruningPipeline(abc.ABC):
     def visualize_results(self) -> None:
         """Produce plots comparing the baseline and pruned model."""
         if self.pruning_method is not None:
+            self.logger.info("Visualizing pruning results")
             self.pruning_method.visualize_comparison()
             self.pruning_method.visualize_pruned_filters()
 
     def save_pruning_results(self, path: str | Path) -> None:
         """Delegate result saving to the active pruning method."""
         if self.pruning_method is not None:
+            self.logger.info("Saving pruning results to %s", path)
             self.pruning_method.save_results(path)
 


### PR DESCRIPTION
## Summary
- add helper package with logger, metric and experiment managers
- integrate logger into pipeline classes
- document helper utilities in README

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849f248ac608324bb35ef5a8466668d