### PR TITLE
Implement L1 and random pruning with adaptive reconfig

### DIFF
--- a/pipeline/model_reconfig.py
+++ b/pipeline/model_reconfig.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import torch
+from torch import nn
+
+from helper import get_logger, Logger
+from ultralytics_pruning import YOLO
+
+
+class ModelReconfiguration:
+    """Base interface for model reconfiguration strategies."""
+
+    def reconfigure_model(
+        self, pruned_model: YOLO, output_path: Optional[str] = None, mismatch_callback=None
+    ) -> YOLO:
+        raise NotImplementedError
+
+
+class AdaptiveLayerReconfiguration(ModelReconfiguration):
+    """Reconfigure pruned models by adapting convolution channels."""
+
+    def __init__(self, logger: Optional[Logger] = None) -> None:
+        self.logger = logger or get_logger()
+
+    def reconfigure_model(
+        self, pruned_model: YOLO, output_path: Optional[str] = None, mismatch_callback=None
+    ) -> YOLO:
+        self.logger.info("Applying Adaptive Layer Reconfiguration")
+        model = pruned_model.model
+        backbone = list(model.model[:10])
+
+        # Gather output channels for backbone modules
+        channel_map = {}
+        for i, module in enumerate(backbone):
+            last_conv = None
+            name = None
+            for n, m in module.named_modules():
+                if isinstance(m, nn.Conv2d):
+                    last_conv = m
+                    name = n
+            if last_conv is not None:
+                channel_map[i] = last_conv.out_channels
+                self.logger.debug(f"Layer {i} output channels: {last_conv.out_channels}")
+
+        # Adjust mismatched channels within backbone
+        for i in range(len(backbone) - 1):
+            out_ch = channel_map.get(i)
+            if out_ch is None:
+                continue
+            next_module = backbone[i + 1]
+            for name, sub in next_module.named_modules():
+                if isinstance(sub, nn.Conv2d):
+                    in_ch = sub.in_channels
+                    if in_ch != out_ch:
+                        if mismatch_callback:
+                            mismatch_callback(i + 1, in_ch, out_ch)
+                        self.logger.debug(
+                            f"Adapting module {i+1} conv {name}: {in_ch} -> {out_ch}"
+                        )
+                        new_conv = nn.Conv2d(
+                            out_ch,
+                            sub.out_channels,
+                            kernel_size=sub.kernel_size,
+                            stride=sub.stride,
+                            padding=sub.padding,
+                            dilation=sub.dilation,
+                            bias=sub.bias is not None,
+                            padding_mode=sub.padding_mode,
+                            groups=1,
+                        )
+                        nn.init.kaiming_normal_(new_conv.weight)
+                        if sub.bias is not None:
+                            nn.init.zeros_(new_conv.bias)
+                        parent = next_module
+                        attr = name
+                        if "." in name:
+                            *parents, attr = name.split(".")
+                            parent = next_module.get_submodule(".".join(parents))
+                        setattr(parent, attr, new_conv)
+                    break
+
+        # Align head with backbone output
+        if len(model.model) > 10 and 9 in channel_map:
+            head = model.model[10]
+            out_ch = channel_map[9]
+            for name, sub in head.named_modules():
+                if isinstance(sub, nn.Conv2d):
+                    in_ch = sub.in_channels
+                    if in_ch != out_ch:
+                        if mismatch_callback:
+                            mismatch_callback("head", in_ch, out_ch)
+                        self.logger.debug(
+                            f"Adapting head conv {name}: {in_ch} -> {out_ch}"
+                        )
+                        new_conv = nn.Conv2d(
+                            out_ch,
+                            sub.out_channels,
+                            kernel_size=sub.kernel_size,
+                            stride=sub.stride,
+                            padding=sub.padding,
+                            dilation=sub.dilation,
+                            bias=sub.bias is not None,
+                            padding_mode=sub.padding_mode,
+                            groups=1,
+                        )
+                        nn.init.kaiming_normal_(new_conv.weight)
+                        if sub.bias is not None:
+                            nn.init.zeros_(new_conv.bias)
+                        parent = head
+                        attr = name
+                        if "." in name:
+                            *parents, attr = name.split(".")
+                            parent = head.get_submodule(".".join(parents))
+                        setattr(parent, attr, new_conv)
+                    break
+
+        if output_path:
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            pruned_model.save(output_path)
+
+        return pruned_model
+

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from .base_pipeline import BasePruningPipeline
 from prune_methods.base import BasePruningMethod
 from helper import get_logger, Logger
+from .model_reconfig import AdaptiveLayerReconfiguration
 
 from ultralytics_pruning import YOLO
 from ultralytics_pruning.utils.torch_utils import get_flops, get_num_params
@@ -23,6 +24,7 @@ class PruningPipeline(BasePruningPipeline):
     ) -> None:
         super().__init__(model_path, data, workdir, pruning_method, logger)
         self.model: YOLO | None = None
+        self.reconfigurator = AdaptiveLayerReconfiguration(logger=self.logger)
 
     def load_model(self) -> None:
         """Load the YOLO model from ``self.model_path``."""
@@ -74,6 +76,8 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is None:
             raise NotImplementedError
         self.logger.info("Reconfiguring pruned model")
+        if self.model is not None:
+            self.reconfigurator.reconfigure_model(self.model)
 
     def calc_pruned_stats(self) -> Dict[str, float]:
         """Calculate parameter count and FLOPs after pruning."""

--- a/prune_methods/methods.py
+++ b/prune_methods/methods.py
@@ -9,33 +9,64 @@ added later.
 from __future__ import annotations
 
 
+import random
+from typing import List
+
+import torch
+from torch import nn
+from torch.nn.utils import prune
+
 from .base import BasePruningMethod
 
 
 class Method1(BasePruningMethod):
-    """Stub pruning method #1."""
+    """Pruning based on L1-norm of convolutional filters."""
 
-    def analyze_model(self) -> None:  # pragma: no cover - placeholder
-        pass
+    def __init__(self, model: any, workdir: str = "runs/pruning") -> None:
+        super().__init__(model, workdir)
+        self.layers: List[nn.Conv2d] = []
+        self.ratio = 0.0
 
-    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
-        pass
+    def analyze_model(self) -> None:
+        """Collect convolution layers from the first 10 backbone modules."""
+        backbone = list(self.model.model[:10])
+        for module in backbone:
+            for m in module.modules():
+                if isinstance(m, nn.Conv2d):
+                    self.layers.append(m)
 
-    def apply_pruning(self) -> None:  # pragma: no cover
-        pass
+    def generate_pruning_mask(self, ratio: float) -> None:
+        self.ratio = ratio
+
+    def apply_pruning(self) -> None:
+        for conv in self.layers:
+            prune.ln_structured(conv, name="weight", amount=self.ratio, n=1, dim=0)
+            prune.remove(conv, "weight")
 
 
 class Method2(BasePruningMethod):
-    """Stub pruning method #2."""
+    """Random structured pruning of convolutional filters."""
 
-    def analyze_model(self) -> None:  # pragma: no cover - placeholder
-        pass
+    def __init__(self, model: any, workdir: str = "runs/pruning") -> None:
+        super().__init__(model, workdir)
+        self.layers: List[nn.Conv2d] = []
+        self.ratio = 0.0
 
-    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover
-        pass
+    def analyze_model(self) -> None:
+        """Collect convolution layers from the first 10 backbone modules."""
+        backbone = list(self.model.model[:10])
+        for module in backbone:
+            for m in module.modules():
+                if isinstance(m, nn.Conv2d):
+                    self.layers.append(m)
 
-    def apply_pruning(self) -> None:  # pragma: no cover
-        pass
+    def generate_pruning_mask(self, ratio: float) -> None:
+        self.ratio = ratio
+
+    def apply_pruning(self) -> None:
+        for conv in self.layers:
+            prune.random_structured(conv, name="weight", amount=self.ratio, dim=0)
+            prune.remove(conv, "weight")
 
 
 class Method3(BasePruningMethod):


### PR DESCRIPTION
## Summary
- add AdaptiveLayerReconfiguration utility for fixing channel mismatches
- integrate reconfiguration step inside `PruningPipeline`
- implement `Method1` and `Method2` to prune using L1-norm and random criteria

## Testing
- `python -m py_compile pipeline/model_reconfig.py pipeline/pruning_pipeline.py prune_methods/methods.py`

------
https://chatgpt.com/codex/tasks/task_b_6849f7a8227483249d1554389b6fe8c9