### PR TITLE
Fix imports in computation_metrics

### DIFF
--- a/helper/metrices/computation_metrics.py
+++ b/helper/metrices/computation_metrics.py
@@ -3,8 +3,7 @@ from typing import Dict, Any, Tuple, Optional, List
 import logging
 import time
 
-import numpy as np
-import torch
+from .base_metric import BaseMetric
 
 try:
     import psutil


### PR DESCRIPTION
## Summary
- remove unused numpy and torch imports
- import BaseMetric from local module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a00a572848324ae5e6972154c45f8