### PR TITLE
Add modular pruning pipeline

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,3 +1,11 @@
 from .base_pipeline import BasePruningPipeline
 from .pruning_pipeline import PruningPipeline
-__all__ = ["BasePruningPipeline", "PruningPipeline"]
+from pruning_pipeline.context import PipelineContext
+from pruning_pipeline.step import PipelineStep
+
+__all__ = [
+    "BasePruningPipeline",
+    "PruningPipeline",
+    "PipelineContext",
+    "PipelineStep",
+]

--- a/pruning_pipeline/__init__.py
+++ b/pruning_pipeline/__init__.py
@@ -1,0 +1,35 @@
+from .context import PipelineContext
+from .step import PipelineStep
+
+# Step classes are imported lazily by consumers to avoid heavy dependencies at
+# package import time. They are re-exported here for convenience.
+from importlib import import_module
+
+
+def __getattr__(name: str):
+    if name in {
+        "LoadModelStep",
+        "TrainStep",
+        "AnalyzeModelStep",
+        "GenerateMasksStep",
+        "ApplyPruningStep",
+        "ReconfigureModelStep",
+        "CalcStatsStep",
+        "CompareModelsStep",
+    }:
+        module = import_module(f"pruning_pipeline.step.{name.lower()}")
+        return getattr(module, name)
+    raise AttributeError(name)
+
+__all__ = [
+    "PipelineContext",
+    "PipelineStep",
+    "LoadModelStep",
+    "TrainStep",
+    "AnalyzeModelStep",
+    "GenerateMasksStep",
+    "ApplyPruningStep",
+    "ReconfigureModelStep",
+    "CalcStatsStep",
+    "CompareModelsStep",
+]

--- a/pruning_pipeline/context.py
+++ b/pruning_pipeline/context.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from helper import Logger, get_logger
+from prune_methods.base import BasePruningMethod
+
+
+@dataclass
+class PipelineContext:
+    """Container for objects shared across pipeline steps."""
+
+    model_path: str
+    data: str
+    workdir: Path = Path("runs/pruning")
+    pruning_method: Optional[BasePruningMethod] = None
+    logger: Logger = field(default_factory=get_logger)
+    model: Any = None
+    initial_stats: Dict[str, float] = field(default_factory=dict)
+    pruned_stats: Dict[str, float] = field(default_factory=dict)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.workdir = Path(self.workdir)
+        self.workdir.mkdir(parents=True, exist_ok=True)
+
+__all__ = ["PipelineContext"]

--- a/pruning_pipeline/step/__init__.py
+++ b/pruning_pipeline/step/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import abc
+
+
+class PipelineStep(abc.ABC):
+    """Base class for all pipeline steps."""
+
+    @abc.abstractmethod
+    def run(self, context: "PipelineContext") -> None:
+        """Execute the step, mutating ``context`` in place."""
+        raise NotImplementedError
+
+__all__ = ["PipelineStep"]

--- a/pruning_pipeline/step/analyze.py
+++ b/pruning_pipeline/step/analyze.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class AnalyzeModelStep(PipelineStep):
+    """Analyze the model using the configured pruning method."""
+
+    def run(self, context: PipelineContext) -> None:
+        if context.pruning_method is None:
+            raise NotImplementedError
+        context.logger.info("Analyzing model structure")
+        context.pruning_method.analyze_model()
+
+__all__ = ["AnalyzeModelStep"]

--- a/pruning_pipeline/step/apply_pruning.py
+++ b/pruning_pipeline/step/apply_pruning.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class ApplyPruningStep(PipelineStep):
+    """Apply the generated pruning mask to the model."""
+
+    def run(self, context: PipelineContext) -> None:
+        if context.pruning_method is None:
+            raise NotImplementedError
+        context.logger.info("Applying pruning mask")
+        context.pruning_method.apply_pruning()
+
+__all__ = ["ApplyPruningStep"]

--- a/pruning_pipeline/step/calc_stats.py
+++ b/pruning_pipeline/step/calc_stats.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ultralytics_pruning.utils.torch_utils import get_flops, get_num_params
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class CalcStatsStep(PipelineStep):
+    """Calculate FLOPs and parameter count for the current model."""
+
+    def __init__(self, dest: str) -> None:
+        self.dest = dest
+
+    def run(self, context: PipelineContext) -> None:
+        if context.model is None:
+            raise ValueError("Model is not loaded")
+        context.logger.info("Calculating %s statistics", self.dest)
+        params = get_num_params(context.model.model)
+        flops = get_flops(context.model.model)
+        stats = {"parameters": params, "flops": flops}
+        if self.dest == "initial":
+            context.initial_stats = stats
+        else:
+            context.pruned_stats = stats
+
+__all__ = ["CalcStatsStep"]

--- a/pruning_pipeline/step/compare.py
+++ b/pruning_pipeline/step/compare.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class CompareModelsStep(PipelineStep):
+    """Visualize and save comparison plots using the pruning method."""
+
+    def run(self, context: PipelineContext) -> None:
+        if context.pruning_method is None:
+            return
+        context.logger.info("Visualizing pruning results")
+        context.pruning_method.visualize_comparison()
+        context.pruning_method.visualize_pruned_filters()
+
+__all__ = ["CompareModelsStep"]

--- a/pruning_pipeline/step/generate_masks.py
+++ b/pruning_pipeline/step/generate_masks.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class GenerateMasksStep(PipelineStep):
+    """Generate pruning masks at a given sparsity ratio."""
+
+    def __init__(self, ratio: float) -> None:
+        self.ratio = ratio
+
+    def run(self, context: PipelineContext) -> None:
+        if context.pruning_method is None:
+            raise NotImplementedError
+        context.logger.info("Generating pruning mask at ratio %.2f", self.ratio)
+        context.pruning_method.generate_pruning_mask(self.ratio)
+
+__all__ = ["GenerateMasksStep"]

--- a/pruning_pipeline/step/load_model.py
+++ b/pruning_pipeline/step/load_model.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from ultralytics_pruning import YOLO
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class LoadModelStep(PipelineStep):
+    """Load a YOLO model from ``context.model_path``."""
+
+    def run(self, context: PipelineContext) -> None:
+        context.logger.info("Loading model from %s", context.model_path)
+        context.model = YOLO(context.model_path)
+
+__all__ = ["LoadModelStep"]

--- a/pruning_pipeline/step/reconfigure.py
+++ b/pruning_pipeline/step/reconfigure.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from ..context import PipelineContext
+from . import PipelineStep
+from ..model_reconfig import AdaptiveLayerReconfiguration
+
+
+class ReconfigureModelStep(PipelineStep):
+    """Reconfigure pruned model layers to match pruned channels."""
+
+    def __init__(self) -> None:
+        self.reconfigurator = AdaptiveLayerReconfiguration()
+
+    def run(self, context: PipelineContext) -> None:
+        if context.model is None:
+            raise ValueError("Model is not loaded")
+        context.logger.info("Reconfiguring model")
+        self.reconfigurator.reconfigure_model(context.model)
+
+__all__ = ["ReconfigureModelStep"]

--- a/pruning_pipeline/step/train.py
+++ b/pruning_pipeline/step/train.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class TrainStep(PipelineStep):
+    """Train or finetune the model using ``YOLO.train``."""
+
+    def __init__(self, phase: str, **train_kwargs: Any) -> None:
+        self.phase = phase
+        self.train_kwargs = train_kwargs
+
+    def run(self, context: PipelineContext) -> None:
+        if context.model is None:
+            raise ValueError("Model is not loaded")
+        context.logger.info("Training model (%s)", self.phase)
+        metrics = context.model.train(data=context.data, **self.train_kwargs)
+        context.metrics[self.phase] = metrics or {}
+
+__all__ = ["TrainStep"]

--- a/tests/test_load_model_step.py
+++ b/tests/test_load_model_step.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pruning_pipeline.context import PipelineContext
+
+dummy = MagicMock(name="YOLO")
+module = types.SimpleNamespace(YOLO=MagicMock(return_value=dummy))
+sys.modules.setdefault("ultralytics_pruning", module)
+from pruning_pipeline.step.load_model import LoadModelStep
+
+
+def test_load_model_step_updates_context():
+    ctx = PipelineContext(model_path="yolov8n.yaml", data="data.yaml")
+    step = LoadModelStep()
+    step.run(ctx)
+    module.YOLO.assert_called_with("yolov8n.yaml")
+    assert ctx.model is dummy


### PR DESCRIPTION
## Summary
- implement step-based pruning pipeline
- create PipelineContext container
- expose steps and context in package
- refactor pipeline to iterate over steps
- update README for new workflow
- add unit test for LoadModelStep

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a033387988324b9a4989d445d6b60