### PR TITLE
Add camel_to_snake and lazy step imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ below. The example expects the dataset to be defined in a YAML file following
 Ultralytics' format with `train`, `val` and `nc` fields.
 
 ```python
-from pipeline import PruningPipeline
-from pipeline.step import (
+from pipeline import (
+    PruningPipeline,
     LoadModelStep,
     CalcStatsStep,
     TrainStep,
@@ -57,7 +57,8 @@ ultralytics_pruning/     # fork of the Ultralytics package
 ```
 
 Importing from `pipeline` exposes both `BasePruningPipeline` and
-`PruningPipeline`.
+`PruningPipeline`. For convenience all step classes such as `LoadModelStep`
+or `TrainStep` are also available directly from the top-level package.
 
 ## Extending `BasePruningPipeline`
 
@@ -104,8 +105,8 @@ strategy.
 A complete workflow typically looks like the following:
 
 ```python
-from pipeline import PruningPipeline
-from pipeline.step import (
+from pipeline import (
+    PruningPipeline,
     LoadModelStep,
     CalcStatsStep,
     TrainStep,

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,4 +1,12 @@
 from importlib import import_module
+import re
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert CamelCase names to snake_case."""
+    s1 = re.sub("(.)([A-Z][a-z0-9]+)", r"\1_\2", name)
+    s2 = re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1)
+    return s2.lower()
 
 __all__ = [
     "BasePruningPipeline",
@@ -35,6 +43,16 @@ def __getattr__(name: str):
         "CalcStatsStep",
         "CompareModelsStep",
     }:
-        module = import_module(f"pipeline.step.{name.lower()}")
+        module_name = camel_to_snake(name)
+        if module_name.endswith("_step"):
+            module_name = module_name[:-5]
+        try:
+            module = import_module(f"pipeline.step.{module_name}")
+        except ModuleNotFoundError:
+            if module_name.endswith("_model"):
+                module_name = module_name[:-6]
+            elif module_name.endswith("_models"):
+                module_name = module_name[:-7]
+            module = import_module(f"pipeline.step.{module_name}")
         return getattr(module, name)
     raise AttributeError(name)

--- a/tests/test_load_model_step.py
+++ b/tests/test_load_model_step.py
@@ -3,6 +3,14 @@ import sys
 import types
 import os
 
+# Stub plotting library required by helper utilities
+matplotlib_stub = types.SimpleNamespace(pyplot=types.SimpleNamespace())
+sys.modules.setdefault("matplotlib", matplotlib_stub)
+sys.modules.setdefault("matplotlib.pyplot", matplotlib_stub.pyplot)
+torch_stub = types.SimpleNamespace(nn=types.SimpleNamespace())
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("torch.nn", torch_stub.nn)
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from pipeline.context import PipelineContext

--- a/tests/test_pipeline_imports.py
+++ b/tests/test_pipeline_imports.py
@@ -1,0 +1,42 @@
+import importlib
+import types
+import sys
+
+# Stub heavy dependencies before importing pipeline modules
+ultra_stub = types.SimpleNamespace(
+    YOLO=object,
+    utils=types.SimpleNamespace(
+        torch_utils=types.SimpleNamespace(get_flops=lambda *a, **k: 0, get_num_params=lambda *a, **k: 0)
+    ),
+)
+sys.modules.setdefault("ultralytics_pruning", ultra_stub)
+sys.modules.setdefault("ultralytics_pruning.utils", ultra_stub.utils)
+sys.modules.setdefault("ultralytics_pruning.utils.torch_utils", ultra_stub.utils.torch_utils)
+torch_stub = types.SimpleNamespace(nn=types.SimpleNamespace(Conv2d=object))
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("torch.nn", torch_stub.nn)
+matplotlib_stub = types.SimpleNamespace(pyplot=types.SimpleNamespace())
+sys.modules.setdefault("matplotlib", matplotlib_stub)
+sys.modules.setdefault("matplotlib.pyplot", matplotlib_stub.pyplot)
+
+from pipeline import (
+    LoadModelStep,
+    TrainStep,
+    AnalyzeModelStep,
+    GenerateMasksStep,
+    ApplyPruningStep,
+    ReconfigureModelStep,
+    CalcStatsStep,
+    CompareModelsStep,
+)
+
+
+def test_step_classes_resolve_from_pipeline():
+    assert LoadModelStep is importlib.import_module("pipeline.step.load_model").LoadModelStep
+    assert TrainStep is importlib.import_module("pipeline.step.train").TrainStep
+    assert AnalyzeModelStep is importlib.import_module("pipeline.step.analyze").AnalyzeModelStep
+    assert GenerateMasksStep is importlib.import_module("pipeline.step.generate_masks").GenerateMasksStep
+    assert ApplyPruningStep is importlib.import_module("pipeline.step.apply_pruning").ApplyPruningStep
+    assert ReconfigureModelStep is importlib.import_module("pipeline.step.reconfigure").ReconfigureModelStep
+    assert CalcStatsStep is importlib.import_module("pipeline.step.calc_stats").CalcStatsStep
+    assert CompareModelsStep is importlib.import_module("pipeline.step.compare").CompareModelsStep


### PR DESCRIPTION
## Summary
- add a small `camel_to_snake` converter in `pipeline.__init__`
- resolve step classes lazily using the helper
- document that steps can be imported from the top-level package
- update quick start and example snippets
- add unit tests for the new behaviour and patch test dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a76768a548324bdae1bfda68b3b95