### PR TITLE
Enable matplotlib optional import

### DIFF
--- a/helper/experiment_manager.py
+++ b/helper/experiment_manager.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
-import matplotlib.pyplot as plt
-
 
 class ExperimentManager:
     """Manage multiple pruning experiments and produce comparisons."""
@@ -24,6 +22,11 @@ class ExperimentManager:
     def compare_pruning_methods(self) -> None:
         """Visualize mAP against pruning ratio for all experiments."""
         if not self.results:
+            return
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+        except ImportError:
+            # matplotlib is optional; skip plotting if unavailable
             return
         ratios = [r["ratio"] for r in self.results]
         maps = [r["metrics"].get("mAP", 0) for r in self.results]

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -1,0 +1,24 @@
+import builtins
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from helper.experiment_manager import ExperimentManager
+
+
+def test_compare_pruning_methods_without_matplotlib(monkeypatch, tmp_path):
+    mgr = ExperimentManager("yolo", workdir=tmp_path)
+    mgr.add_result("dummy", 0.5, {"mAP": 0.1})
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "matplotlib.pyplot":
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    mgr.compare_pruning_methods()  # Should handle missing matplotlib gracefully

--- a/tests/test_load_model_step.py
+++ b/tests/test_load_model_step.py
@@ -5,6 +5,17 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+# Provide a lightweight stub for prune_methods.base so importing PipelineContext
+# does not require heavy dependencies like torch during tests.
+if "prune_methods.base" not in sys.modules:
+    stub = types.ModuleType("prune_methods.base")
+
+    class BasePruningMethod:  # pragma: no cover - simple placeholder
+        pass
+
+    stub.BasePruningMethod = BasePruningMethod
+    sys.modules["prune_methods.base"] = stub
+
 from pipeline.context import PipelineContext
 
 dummy = MagicMock(name="YOLO")


### PR DESCRIPTION
## Summary
- load matplotlib lazily in `ExperimentManager.compare_pruning_methods`
- stub heavy pruning dependencies in tests
- add test covering missing matplotlib

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a78714254832491eddc29d7c37b24