### PR TITLE
Add CLI help and continue mode tests

### DIFF
--- a/tests/test_continue_mode.py
+++ b/tests/test_continue_mode.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import types
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pruning_comparison
+
+
+def _prepare_args(tmp_dir, cont):
+    return types.SimpleNamespace(
+        model="m.pt",
+        data="d.yaml",
+        device="cpu",
+        runs_dir="experiments",
+        methods=["l1"],
+        ratios=[0.2],
+        baseline_epochs=1,
+        no_baseline=True,
+        debug=False,
+        cont=cont,
+    )
+
+
+def _setup_env(monkeypatch, tmp_path):
+    fake_file = tmp_path / "repo" / "pruning_comparison.py"
+    fake_file.parent.mkdir(parents=True)
+    monkeypatch.setattr(pruning_comparison, "__file__", str(fake_file))
+    monkeypatch.setattr(
+        pruning_comparison,
+        "datetime",
+        types.SimpleNamespace(now=lambda: datetime(2023, 1, 1, 0, 0, 0)),
+    )
+    calls = []
+
+    def fake_run(cmd, debug=False):
+        calls.append(cmd)
+
+    monkeypatch.setattr(pruning_comparison, "run_command", fake_run)
+    return calls, tmp_path / "experiments" / "pruning_comparison_20230101_000000"
+
+
+def test_continue_skips_completed_run(monkeypatch, tmp_path):
+    calls, base_dir = _setup_env(monkeypatch, tmp_path)
+    args = _prepare_args(tmp_path, cont=True)
+    monkeypatch.setattr(pruning_comparison, "parse_args", lambda: args)
+    run_dir = base_dir / "l1_r0_2"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / ".experiment_complete").touch()
+    pruning_comparison.main()
+    assert calls == []
+
+
+def test_continue_executes_when_missing(monkeypatch, tmp_path):
+    calls, base_dir = _setup_env(monkeypatch, tmp_path)
+    args = _prepare_args(tmp_path, cont=True)
+    monkeypatch.setattr(pruning_comparison, "parse_args", lambda: args)
+    pruning_comparison.main()
+    assert len(calls) == 1
+    run_dir = base_dir / "l1_r0_2"
+    assert (run_dir / ".experiment_complete").exists()

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+import importlib
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_main_help_shows_options(capsys, monkeypatch):
+    # Stub heavy dependencies so importing main works
+    sys.modules['torch'] = types.ModuleType('torch')
+    sys.modules['torch.nn'] = types.ModuleType('torch.nn')
+
+    up = types.ModuleType('ultralytics_pruning')
+    utils = types.ModuleType('ultralytics_pruning.utils')
+    torch_utils = types.ModuleType('ultralytics_pruning.utils.torch_utils')
+    torch_utils.get_flops = lambda *a, **k: 0
+    torch_utils.get_num_params = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
+    up.utils = utils
+    up.YOLO = lambda *a, **k: None
+    sys.modules['ultralytics_pruning'] = up
+    sys.modules['ultralytics_pruning.utils'] = utils
+    sys.modules['ultralytics_pruning.utils.torch_utils'] = torch_utils
+    mpl = types.ModuleType('matplotlib')
+    plt = types.ModuleType('matplotlib.pyplot')
+    sys.modules['matplotlib'] = mpl
+    sys.modules['matplotlib.pyplot'] = plt
+
+    main = importlib.import_module('main')
+    monkeypatch.setattr(sys, 'argv', ['main.py', '--help'])
+    with pytest.raises(SystemExit):
+        main.parse_args()
+    help_text = capsys.readouterr().out
+    for opt in [
+        '--model',
+        '--data',
+        '--workdir',
+        '--resume',
+        '--baseline-epochs',
+        '--finetune-epochs',
+        '--batch-size',
+        '--ratios',
+    ]:
+        assert opt in help_text


### PR DESCRIPTION
## Summary
- add regression test verifying `main.py --help` output
- test continue mode logic in `pruning_comparison.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a7c6eed2c8324a8d774ffaa4a45d2