### PR TITLE
Fix docs for metrics retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ pipeline = PruningPipeline(
 )
 
 context = pipeline.run_pipeline()
-print(context.record_metrics())
+print(pipeline.record_metrics())
 ```
 
 The YAML file describing the dataset should have at least the following keys:

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -66,7 +66,7 @@ A typical set of steps might look as follows:
 8. `CalcStatsStep("pruned")`
 9. `TrainStep("finetune", epochs=3)`
 
-`PruningPipeline` will execute them sequentially, passing the same context object to each. Statistics and metrics are accumulated inside `context` and can be retrieved at the end via `context.record_metrics()`.
+`PruningPipeline` will execute them sequentially, passing the same context object to each. Statistics and metrics are accumulated inside `context` and can be retrieved at the end via `pipeline.record_metrics()` or directly from `context.metrics`.
 
 This modular structure makes it easy to customise or extend the pruning process by defining new step classes or reordering existing ones.
 


### PR DESCRIPTION
## Summary
- update README snippets to use `pipeline.record_metrics()`
- clarify metrics retrieval in pipeline docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a83cf0568832486095c8fd2975070