### PR TITLE
Add device option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,5 +175,4 @@ python main.py --model yolov8n-seg.pt --data coco8.yaml \
 
 Add `--resume` to continue interrupted runs.
 
-The training device is chosen automatically by PyTorch and cannot be set via a
-command-line option.
+Use `--device` to select the training device. The default is `cuda:0`.

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ class TrainConfig:
     finetune_epochs: int = 3
     batch_size: int = 16
     ratios: List[float] = field(default_factory=lambda: [0.2, 0.4, 0.6, 0.8])
+    device: str | int | list = 0
 
 
 def execute_pipeline(
@@ -80,6 +81,7 @@ def execute_pipeline(
         project=str(workdir),
         name="baseline" if method_cls is None else "pretrain",
         resume=resume,
+        device=config.device,
     )
     if method_cls is not None:
         pipeline.analyze_structure()
@@ -93,6 +95,7 @@ def execute_pipeline(
             project=str(workdir),
             name="finetune",
             resume=resume,
+            device=config.device,
         )
     pipeline.visualize_results()
     pipeline.save_pruning_results(workdir / "results")
@@ -155,6 +158,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--baseline-epochs", type=int, default=1, help="Number of pretraining epochs")
     parser.add_argument("--finetune-epochs", type=int, default=3, help="Number of finetuning epochs")
     parser.add_argument("--batch-size", type=int, default=16, help="Training batch size")
+    parser.add_argument("--device", default="cuda:0", help="Training device for YOLO")
     parser.add_argument(
         "--ratios",
         nargs="+",
@@ -203,6 +207,7 @@ def run_comparison(args: argparse.Namespace) -> None:
             finetune_epochs=args.finetune_epochs,
             batch_size=args.batch_size,
             ratios=[0],
+            device=args.device,
         )
         execute_pipeline(
             args.model,
@@ -232,6 +237,7 @@ def run_comparison(args: argparse.Namespace) -> None:
                 finetune_epochs=args.finetune_epochs,
                 batch_size=args.batch_size,
                 ratios=[ratio],
+                device=args.device,
             )
             execute_pipeline(
                 args.model,
@@ -288,6 +294,7 @@ def main() -> None:
         finetune_epochs=args.finetune_epochs,
         batch_size=args.batch_size,
         ratios=args.ratios,
+        device=args.device,
     )
     methods = [METHODS_MAP[m] for m in args.methods]
     runner = ExperimentRunner(

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -66,12 +66,12 @@ class PruningPipeline(BasePruningPipeline):
         self.initial_stats = {"parameters": params, "flops": flops}
         return self.initial_stats
 
-    def pretrain(self, **train_kwargs: Any) -> Dict[str, Any]:
+    def pretrain(self, *, device: str | int | list = 0, **train_kwargs: Any) -> Dict[str, Any]:
         """Optional pretraining step to run before pruning."""
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Pretraining model")
-        metrics = self.model.train(data=self.data, **train_kwargs)
+        metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self.metrics["pretrain"] = metrics
         return metrics or {}
 
@@ -114,12 +114,12 @@ class PruningPipeline(BasePruningPipeline):
         self.pruned_stats = {"parameters": params, "flops": flops}
         return self.pruned_stats
 
-    def finetune(self, **train_kwargs: Any) -> Dict[str, Any]:
+    def finetune(self, *, device: str | int | list = 0, **train_kwargs: Any) -> Dict[str, Any]:
         """Finetune the pruned model."""
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Finetuning pruned model")
-        metrics = self.model.train(data=self.data, **train_kwargs)
+        metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self.metrics["finetune"] = metrics
         return metrics or {}
 

--- a/tests/test_continue_mode.py
+++ b/tests/test_continue_mode.py
@@ -37,6 +37,7 @@ def _prepare_args(tmp_dir, cont):
         baseline_epochs=1,
         finetune_epochs=1,
         batch_size=1,
+        device="cuda:0",
         no_baseline=True,
         debug=False,
         cont=cont,


### PR DESCRIPTION
## Summary
- allow selecting training device via TrainConfig and CLI
- forward device argument through pretrain/finetune
- document default device in README
- update tests for new `--device` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684aa82080f08324a16bbcd642d27849