### PR TITLE
Update README batch script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ python main.py --model yolov8n-seg.pt --data coco8.yaml \
 
 Add `--resume` to continue interrupted runs.
 
-Use `--device` to select the training device. The default is `cuda:0`.
+Use `--device` to select the training device (defaults to `cuda:0`).


### PR DESCRIPTION
## Summary
- clarify that `--device` sets the training device and defaults to `cuda:0`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684aadbb6dc8832489d5134c84e05835