### PR TITLE
Integrate biotech dataset as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ steps = [
     CalcStatsStep("pruned"),
 ]
 
-pipeline = PruningPipeline("yolov8n-seg.pt", data="coco8.yaml", steps=steps)
+pipeline = PruningPipeline("yolov8n-seg.pt", data="biotech_model_train.yaml", steps=steps)
 context = pipeline.run_pipeline()
 print(context.metrics)
 ```
@@ -129,7 +129,7 @@ steps = [
 
 pipeline = PruningPipeline(
     model_path="yolov8n-seg.pt",
-    data="coco8.yaml",  # dataset YAML with 'train', 'val' and 'nc'
+    data="biotech_model_train.yaml",  # dataset YAML with 'train', 'val' and 'nc'
     workdir="runs/pruning",
     steps=steps,
 )
@@ -169,9 +169,10 @@ maintain.
 Use `main.py` to run all pruning methods across several ratios in one go:
 
 ```bash
-python main.py --model yolov8n-seg.pt --data coco8.yaml \
+python main.py --model yolov8n-seg.pt \
     --baseline-epochs 1 --finetune-epochs 3 --batch-size 16 --ratios 0.2 0.4 0.6 0.8
 ```
+The dataset defaults to `biotech_model_train.yaml` if `--data` is not supplied.
 
 Add `--resume` to continue interrupted runs.
 

--- a/main.py
+++ b/main.py
@@ -152,7 +152,11 @@ def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run multiple pruning experiments")
     parser.add_argument("--model", required=True, help="Path to the model weights")
-    parser.add_argument("--data", required=True, help="Dataset YAML describing train/val paths")
+    parser.add_argument(
+        "--data",
+        default="biotech_model_train.yaml",
+        help="Dataset YAML describing train/val paths",
+    )
     parser.add_argument("--workdir", default="runs/experiments", help="Output directory")
     parser.add_argument("--resume", action="store_true", help="Resume interrupted runs if possible")
     parser.add_argument("--baseline-epochs", type=int, default=1, help="Number of pretraining epochs")


### PR DESCRIPTION
## Summary
- use `biotech_model_train.yaml` as the default dataset in `main.py`
- update README examples to reflect new default dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684aaf33c5448324a2d8e0b8807cb22f