### PR TITLE
Disable YOLO training plots by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    TrainStep("pretrain", epochs=1),
+    TrainStep("pretrain", epochs=1, plots=False),
     AnalyzeModelStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
@@ -118,13 +118,13 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    TrainStep("pretrain", epochs=1),
+    TrainStep("pretrain", epochs=1, plots=False),
     AnalyzeModelStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     ReconfigureModelStep(),
     CalcStatsStep("pruned"),
-    TrainStep("finetune", epochs=3),
+    TrainStep("finetune", epochs=3, plots=False),
 ]
 
 pipeline = PruningPipeline(

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -58,13 +58,13 @@ A typical set of steps might look as follows:
 
 1. `LoadModelStep()`
 2. `CalcStatsStep("initial")`
-3. `TrainStep("pretrain", epochs=1)`
+3. `TrainStep("pretrain", epochs=1, plots=False)`
 4. `AnalyzeModelStep()`
 5. `GenerateMasksStep(ratio=0.2)`
 6. `ApplyPruningStep()`
 7. `ReconfigureModelStep()`
 8. `CalcStatsStep("pruned")`
-9. `TrainStep("finetune", epochs=3)`
+9. `TrainStep("finetune", epochs=3, plots=False)`
 
 `PruningPipeline` will execute them sequentially, passing the same context object to each. Statistics and metrics are accumulated inside `context` and can be retrieved at the end via `pipeline.record_metrics()` or directly from `context.metrics`.
 

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -71,6 +71,7 @@ class PruningPipeline(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Pretraining model")
+        train_kwargs.setdefault("plots", False)
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self.metrics["pretrain"] = metrics
         return metrics or {}
@@ -119,6 +120,7 @@ class PruningPipeline(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Finetuning pruned model")
+        train_kwargs.setdefault("plots", False)
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self.metrics["finetune"] = metrics
         return metrics or {}

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -7,7 +7,11 @@ from . import PipelineStep
 
 
 class TrainStep(PipelineStep):
-    """Train or finetune the model using ``YOLO.train``."""
+    """Train or finetune the model using ``YOLO.train``.
+
+    Parameters passed via ``train_kwargs`` are forwarded to ``YOLO.train``. By
+    default plotting is disabled unless ``plots=True`` is specified.
+    """
 
     def __init__(self, phase: str, **train_kwargs: Any) -> None:
         self.phase = phase
@@ -17,6 +21,7 @@ class TrainStep(PipelineStep):
         if context.model is None:
             raise ValueError("Model is not loaded")
         context.logger.info("Training model (%s)", self.phase)
+        self.train_kwargs.setdefault("plots", False)
         metrics = context.model.train(data=context.data, **self.train_kwargs)
         context.metrics[self.phase] = metrics or {}
 


### PR DESCRIPTION
## Summary
- turn off plotting in TrainStep, `pretrain` and `finetune`
- mention `plots=False` in docs and examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684accc760d48324a39555262124d9b8