### PR TITLE
Improve pruning logs

### DIFF
--- a/prune_methods/l1_norm.py
+++ b/prune_methods/l1_norm.py
@@ -38,6 +38,12 @@ class L1NormPruningMethod(BasePruningMethod):
             scores = conv.weight.data.abs().sum(dim=(1, 2, 3))
             num_prune = int(conv.out_channels * ratio)
             num_prune = min(max(num_prune, 0), conv.out_channels - 1)
+            self.logger.debug(
+                "Layer %s pruning %d/%d channels",
+                attr,
+                num_prune,
+                conv.out_channels,
+            )
             _, idx = torch.sort(scores)
             mask = torch.ones(conv.out_channels, dtype=torch.bool)
             if num_prune > 0:
@@ -49,7 +55,19 @@ class L1NormPruningMethod(BasePruningMethod):
             conv = getattr(parent, attr)
             keep_idx = mask.nonzero(as_tuple=False).squeeze(1)
             if len(keep_idx) == conv.out_channels:
+                self.logger.debug(
+                    "Layer %s: %d -> %d channels (no pruning applied)",
+                    attr,
+                    conv.out_channels,
+                    len(keep_idx),
+                )
                 continue
+            self.logger.debug(
+                "Layer %s: %d -> %d channels",
+                attr,
+                conv.out_channels,
+                len(keep_idx),
+            )
             new_conv = nn.Conv2d(
                 conv.in_channels,
                 len(keep_idx),

--- a/prune_methods/random_pruning.py
+++ b/prune_methods/random_pruning.py
@@ -37,6 +37,12 @@ class RandomPruningMethod(BasePruningMethod):
             conv = getattr(parent, attr)
             num_prune = int(conv.out_channels * ratio)
             num_prune = min(max(num_prune, 0), conv.out_channels - 1)
+            self.logger.debug(
+                "Layer %s pruning %d/%d channels",
+                attr,
+                num_prune,
+                conv.out_channels,
+            )
             idx = torch.randperm(conv.out_channels)
             mask = torch.ones(conv.out_channels, dtype=torch.bool)
             if num_prune > 0:
@@ -48,7 +54,19 @@ class RandomPruningMethod(BasePruningMethod):
             conv = getattr(parent, attr)
             keep_idx = mask.nonzero(as_tuple=False).squeeze(1)
             if len(keep_idx) == conv.out_channels:
+                self.logger.debug(
+                    "Layer %s: %d -> %d channels (no pruning applied)",
+                    attr,
+                    conv.out_channels,
+                    len(keep_idx),
+                )
                 continue
+            self.logger.debug(
+                "Layer %s: %d -> %d channels",
+                attr,
+                conv.out_channels,
+                len(keep_idx),
+            )
             new_conv = nn.Conv2d(
                 conv.in_channels,
                 len(keep_idx),


### PR DESCRIPTION
## Summary
- add debugging output for how many channels each layer prunes
- log channel counts before/after pruning a layer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684af1adacac83248778dfdefa18289b