### PR TITLE
Add pipeline logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ The dataset defaults to `biotech_model_train.yaml` if `--data` is not supplied.
 
 Add `--resume` to continue interrupted runs.
 
+Each run directory will contain a `pipeline.log` file capturing detailed
+training and pruning output for the selected ratio.
+
 Use `--device` to select the training device (defaults to `cuda:0`).
 
 ## Panduan Setup Lingkungan (Bahasa Indonesia)

--- a/main.py
+++ b/main.py
@@ -59,6 +59,12 @@ def execute_pipeline(
     logger=None,
 ) -> PruningPipeline:
     """Run a full pruning pipeline for ``method_cls`` at ``ratio``."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    log_file = workdir / "pipeline.log"
+    if logger is None:
+        logger = get_logger(log_file=str(log_file))
+    else:
+        get_logger(log_file=str(log_file))
     pipeline = PruningPipeline(model_path, data=data, workdir=str(workdir), logger=logger)
     pipeline.load_model()
     if method_cls is not None:

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -73,6 +73,7 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Pretraining model")
         train_kwargs.setdefault("plots", False)
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
+        self.logger.debug(metrics)
         self.metrics["pretrain"] = metrics
         return metrics or {}
 
@@ -122,6 +123,7 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Finetuning pruned model")
         train_kwargs.setdefault("plots", False)
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
+        self.logger.debug(metrics)
         self.metrics["finetune"] = metrics
         return metrics or {}
 


### PR DESCRIPTION
## Summary
- record metrics at debug level during training
- write pipeline logs for each run
- document log file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684af2e28910832480476f127f6deaf2