### PR TITLE
Add baseline reuse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Use `main.py` to run all pruning methods across several ratios in one go:
 
 ```bash
 python main.py --model yolov8n-seg.pt \
-    --baseline-epochs 1 --finetune-epochs 3 --batch-size 16 --ratios 0.2 0.4 0.6 0.8
+    --baseline-epochs 1 --finetune-epochs 3 --batch-size 16 --ratios 0.2 0.4 0.6 0.8 \
+    --reuse-baseline
 ```
 The dataset defaults to `biotech_model_train.yaml` if `--data` is not supplied.
 

--- a/tests/test_continue_mode.py
+++ b/tests/test_continue_mode.py
@@ -38,6 +38,7 @@ def _prepare_args(tmp_dir, cont):
         finetune_epochs=1,
         batch_size=1,
         device="cuda:0",
+        reuse_baseline=False,
         no_baseline=True,
         debug=False,
         cont=cont,

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -44,6 +44,7 @@ def test_main_help_shows_options(capsys, monkeypatch):
         '--batch-size',
         '--ratios',
         '--device',
+        '--reuse-baseline',
     ]:
         assert opt in help_text
 


### PR DESCRIPTION
## Summary
- allow skipping repeated baseline training
- add `--reuse-baseline` CLI option
- support baseline reuse in comparison and experiment runs
- document the new flag
- adjust tests for updated CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684af3ed1fa88324accc3075a5cb234f