### PR TITLE
Remove reuse-baseline CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ Use `main.py` to run all pruning methods across several ratios in one go:
 
 ```bash
 python main.py --model yolov8n-seg.pt \
-    --baseline-epochs 1 --finetune-epochs 3 --batch-size 16 --ratios 0.2 0.4 0.6 0.8 \
-    --reuse-baseline
+    --baseline-epochs 1 --finetune-epochs 3 --batch-size 16 --ratios 0.2 0.4 0.6 0.8
 ```
 The dataset defaults to `biotech_model_train.yaml` if `--data` is not supplied.
 

--- a/tests/test_continue_mode.py
+++ b/tests/test_continue_mode.py
@@ -38,7 +38,6 @@ def _prepare_args(tmp_dir, cont):
         finetune_epochs=1,
         batch_size=1,
         device="cuda:0",
-        reuse_baseline=False,
         no_baseline=True,
         debug=False,
         cont=cont,

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -44,7 +44,6 @@ def test_main_help_shows_options(capsys, monkeypatch):
         '--batch-size',
         '--ratios',
         '--device',
-        '--reuse-baseline',
     ]:
         assert opt in help_text
 


### PR DESCRIPTION
## Summary
- remove `--reuse-baseline` flag from CLI and tests
- always train baseline once and reuse it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684af6d353448324bb9d3a7e987fa3ba