### PR TITLE
Add plotting utilities and tests

### DIFF
--- a/helper/experiment_manager.py
+++ b/helper/experiment_manager.py
@@ -41,3 +41,75 @@ class ExperimentManager:
         plt.tight_layout()
         plt.savefig(self.workdir / "comparison.png")
         plt.close()
+
+    # ------------------------------------------------------------------
+    # Generic plotting helpers
+    # ------------------------------------------------------------------
+    def _extract_metric(self, data: Dict[str, Any], path: str) -> float | None:
+        """Return metric value located at dotted ``path`` inside ``data``."""
+        parts = path.split(".")
+        value: Any = data
+        for p in parts:
+            if isinstance(value, dict) and p in value:
+                value = value[p]
+            else:
+                return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
+    def plot_line(self, metric: str) -> None:
+        """Plot ``metric`` against ratio for each method."""
+        if not self.results:
+            return
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+        except ImportError:
+            return
+        method_groups: Dict[str, List[tuple[float, float | None]]] = {}
+        for entry in self.results:
+            val = self._extract_metric(entry["metrics"], metric)
+            method_groups.setdefault(entry["method"], []).append((entry["ratio"], val))
+        plt.figure()
+        for method, vals in method_groups.items():
+            vals.sort(key=lambda x: x[0])
+            x = [v[0] for v in vals]
+            y = [v[1] if v[1] is not None else 0 for v in vals]
+            plt.plot(x, y, marker="o", label=method)
+        plt.xlabel("ratio")
+        plt.ylabel(metric)
+        plt.legend()
+        plt.tight_layout()
+        filename = metric.replace(".", "_") + "_line.png"
+        plt.savefig(self.workdir / filename)
+        plt.close()
+
+    def plot_heatmap(self, metric: str) -> None:
+        """Draw heatmap of ``metric`` with methods on x-axis and ratios on y-axis."""
+        if not self.results:
+            return
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+            import numpy as np  # type: ignore
+        except ImportError:
+            return
+        methods = sorted({r["method"] for r in self.results})
+        ratios = sorted({r["ratio"] for r in self.results})
+        matrix = np.full((len(ratios), len(methods)), np.nan)
+        for entry in self.results:
+            i = ratios.index(entry["ratio"])
+            j = methods.index(entry["method"])
+            val = self._extract_metric(entry["metrics"], metric)
+            if val is not None:
+                matrix[i, j] = val
+        plt.figure()
+        im = plt.imshow(matrix, aspect="auto", origin="lower")
+        plt.xticks(range(len(methods)), methods, rotation=45)
+        plt.yticks(range(len(ratios)), [str(r) for r in ratios])
+        plt.xlabel("method")
+        plt.ylabel("ratio")
+        plt.colorbar(im, label=metric)
+        plt.tight_layout()
+        filename = metric.replace(".", "_") + "_heatmap.png"
+        plt.savefig(self.workdir / filename)
+        plt.close()

--- a/main.py
+++ b/main.py
@@ -172,6 +172,9 @@ class ExperimentRunner:
                 self.manager.add_result(method_name, ratio, pipeline.record_metrics())
 
         self.manager.compare_pruning_methods()
+        # Visualize training metrics across ratios and methods
+        self.manager.plot_line("training.mAP")
+        self.manager.plot_heatmap("training.mAP")
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -22,3 +22,21 @@ def test_compare_pruning_methods_without_matplotlib(monkeypatch, tmp_path):
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     mgr.compare_pruning_methods()  # Should handle missing matplotlib gracefully
+
+
+def test_plot_functions_without_matplotlib(monkeypatch, tmp_path):
+    mgr = ExperimentManager("yolo", workdir=tmp_path)
+    mgr.add_result("m1", 0.1, {"training": {"mAP": 0.2}})
+    mgr.add_result("m2", 0.2, {"training": {"mAP": 0.3}})
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "matplotlib.pyplot":
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    mgr.plot_line("training.mAP")
+    mgr.plot_heatmap("training.mAP")


### PR DESCRIPTION
## Summary
- extend `ExperimentManager` with generic `plot_line` and `plot_heatmap`
- update `ExperimentRunner` to call new plotting functions
- add tests ensuring plotting handles missing matplotlib

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b08bd96d88324b3b58ddfc71348a5