### PR TITLE
Add MetricManager integration and CSV export

### DIFF
--- a/helper/experiment_manager.py
+++ b/helper/experiment_manager.py
@@ -15,9 +15,19 @@ class ExperimentManager:
         self.workdir.mkdir(parents=True, exist_ok=True)
         self.results: List[Dict[str, Any]] = []
 
-    def add_result(self, method: str, ratio: float, metrics: Dict[str, Any]) -> None:
-        """Record the metrics for a pruning experiment."""
-        self.results.append({"method": method, "ratio": ratio, "metrics": metrics})
+    def add_result(
+        self,
+        method: str,
+        ratio: float,
+        metrics: Dict[str, Any],
+        csv_path: str | Path | None = None,
+    ) -> None:
+        """Record the metrics and CSV location for a pruning experiment."""
+
+        entry: Dict[str, Any] = {"method": method, "ratio": ratio, "metrics": metrics}
+        if csv_path is not None:
+            entry["csv"] = str(csv_path)
+        self.results.append(entry)
 
     def compare_pruning_methods(self) -> None:
         """Visualize mAP against pruning ratio for all experiments."""

--- a/pipeline/context.py
+++ b/pipeline/context.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from helper import Logger, get_logger
+from helper import Logger, MetricManager, get_logger
 from prune_methods.base import BasePruningMethod
 
 
@@ -21,9 +21,11 @@ class PipelineContext:
     initial_stats: Dict[str, float] = field(default_factory=dict)
     pruned_stats: Dict[str, float] = field(default_factory=dict)
     metrics: Dict[str, Any] = field(default_factory=dict)
+    metrics_mgr: MetricManager = field(init=False)
 
     def __post_init__(self) -> None:
         self.workdir = Path(self.workdir)
         self.workdir.mkdir(parents=True, exist_ok=True)
+        self.metrics_mgr = MetricManager()
 
 __all__ = ["PipelineContext"]

--- a/pipeline/step/calc_stats.py
+++ b/pipeline/step/calc_stats.py
@@ -21,7 +21,25 @@ class CalcStatsStep(PipelineStep):
         stats = {"parameters": params, "flops": flops}
         if self.dest == "initial":
             context.initial_stats = stats
+            context.metrics_mgr.record_pruning({
+                "parameters": {"original": params},
+                "flops": {"original": flops},
+            })
         else:
             context.pruned_stats = stats
+            orig_params = context.initial_stats.get("parameters", params)
+            orig_flops = context.initial_stats.get("flops", flops)
+            context.metrics_mgr.record_pruning({
+                "parameters": {
+                    "pruned": params,
+                    "reduction": orig_params - params,
+                    "reduction_percent": ((orig_params - params) / orig_params * 100) if orig_params else 0,
+                },
+                "flops": {
+                    "pruned": flops,
+                    "reduction": orig_flops - flops,
+                    "reduction_percent": ((orig_flops - flops) / orig_flops * 100) if orig_flops else 0,
+                },
+            })
 
 __all__ = ["CalcStatsStep"]

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -23,6 +23,7 @@ class TrainStep(PipelineStep):
         context.logger.info("Training model (%s)", self.phase)
         self.train_kwargs.setdefault("plots", False)
         metrics = context.model.train(data=context.data, **self.train_kwargs)
+        context.metrics_mgr.record_training(metrics or {})
         context.metrics[self.phase] = metrics or {}
 
 __all__ = ["TrainStep"]

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -95,6 +95,9 @@ def test_device_argument_passed(monkeypatch):
         def save_pruning_results(self, path):
             pass
 
+        def save_metrics_csv(self, path):
+            return Path(path)
+
     monkeypatch.setattr(main, 'PruningPipeline', DummyPipeline)
     main.execute_pipeline('m', 'd', None, 0.2, main.TrainConfig(device=args.device), Path('w'))
     assert calls['pretrain']['device'] == 'cpu'

--- a/tests/test_metrics_csv.py
+++ b/tests/test_metrics_csv.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub heavy dependencies
+sys.modules['torch'] = types.ModuleType('torch')
+sys.modules['torch.nn'] = types.ModuleType('torch.nn')
+
+mpl = types.ModuleType('matplotlib')
+plt = types.ModuleType('matplotlib.pyplot')
+sys.modules['matplotlib'] = mpl
+sys.modules['matplotlib.pyplot'] = plt
+
+dummy = types.SimpleNamespace(model=object())
+dummy.train = lambda *a, **k: {'mAP': 0.1}
+
+up = types.ModuleType('ultralytics')
+up.YOLO = lambda *a, **k: dummy
+utils = types.ModuleType('ultralytics.utils')
+torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+torch_utils.get_flops = lambda *a, **k: 100
+torch_utils.get_num_params = lambda *a, **k: 200
+utils.torch_utils = torch_utils
+up.utils = utils
+
+sys.modules['ultralytics'] = up
+sys.modules['ultralytics.utils'] = utils
+sys.modules['ultralytics.utils.torch_utils'] = torch_utils
+
+import main
+import pipeline.pruning_pipeline as pp
+pp.YOLO = up.YOLO
+pp.get_flops = torch_utils.get_flops
+pp.get_num_params = torch_utils.get_num_params
+
+
+def test_metrics_csv_created(tmp_path):
+    cfg = main.TrainConfig(baseline_epochs=1, finetune_epochs=0, batch_size=1, ratios=[0])
+    _, csv_path = main.execute_pipeline('m.pt', 'd.yaml', None, 0, cfg, tmp_path)
+    assert csv_path.exists()
+    header = csv_path.read_text().splitlines()[0]
+    assert 'training.mAP' in header
+    assert 'pruning.parameters.original' in header


### PR DESCRIPTION
## Summary
- track metrics inside PipelineContext using MetricManager
- store training and pruning metrics in PruningPipeline and steps
- export metrics to CSV after running a pipeline
- propagate CSV path through execute_pipeline and ExperimentRunner
- extend ExperimentManager to save CSV location
- test metrics CSV creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b0b3d375c832494e509c39085787b