### PR TITLE
Add computation monitoring step

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "ReconfigureModelStep",
     "CalcStatsStep",
     "CompareModelsStep",
+    "MonitorComputationStep",
 ]
 
 
@@ -34,6 +35,7 @@ def __getattr__(name: str):
         "ReconfigureModelStep": "reconfigure",
         "CalcStatsStep": "calc_stats",
         "CompareModelsStep": "compare",
+        "MonitorComputationStep": "monitor_computation",
     }
     if name in step_modules:
         module = import_module(f"pipeline.step.{step_modules[name]}")

--- a/pipeline/step/monitor_computation.py
+++ b/pipeline/step/monitor_computation.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, Any
+
+from helper.metric_manager import MetricManager
+from helper.metrics.computation_metrics import GPUMetric, MemoryMetric, PowerMetric
+
+from ..context import PipelineContext
+from . import PipelineStep
+
+
+class MonitorComputationStep(PipelineStep):
+    """Sample GPU, memory and power usage around a training phase."""
+
+    def __init__(self, phase: str) -> None:
+        self.phase = phase
+        self.gpu = GPUMetric()
+        self.memory = MemoryMetric()
+        self.power = PowerMetric()
+        self._start_time = 0.0
+
+    def start(self) -> None:
+        """Begin metric collection."""
+        self._start_time = time.time()
+        self.gpu.reset()
+        self.memory.reset()
+        self.power.reset()
+        self.gpu.collect()
+        self.memory.collect()
+        self.power.collect()
+
+    def stop(self, mgr: MetricManager) -> Dict[str, Any]:
+        """Stop metric collection and record summary using ``mgr``."""
+        elapsed = time.time() - self._start_time
+        gpu_metrics = self.gpu.collect()
+        mem_metrics = self.memory.collect()
+        self.power.collect(interval=elapsed)
+        gpu_summary = self.gpu.get_summary()
+        mem_summary = self.memory.get_summary()
+        power_summary = self.power.get_summary()
+        metrics = {
+            "elapsed_seconds": elapsed,
+            "total_time": elapsed,
+            "total_time_minutes": elapsed / 60.0,
+            "gpu_utilization": gpu_summary.get("avg_utilization", 0.0),
+            "gpu_memory_used_mb": gpu_metrics.get("gpu_memory_used_mb", 0.0),
+            "gpu_memory_total_mb": gpu_metrics.get("gpu_memory_total_mb", 0.0),
+            "ram_used_mb": mem_metrics.get("ram_used_mb", 0.0),
+            "ram_total_mb": mem_metrics.get("ram_total_mb", 0.0),
+            "ram_percent": mem_summary.get("avg_ram_percent", 0.0),
+            "power_usage_watts": power_summary.get("avg_power_watts", 0.0),
+        }
+        mgr.record_computation(metrics)
+        return metrics
+
+    def run(self, context: PipelineContext) -> None:  # pragma: no cover - not used in tests
+        metrics = self.stop(context.metrics_mgr)
+        context.metrics.setdefault("computation", {})[self.phase] = metrics
+
+
+__all__ = ["MonitorComputationStep"]

--- a/tests/test_monitor_step.py
+++ b/tests/test_monitor_step.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pipeline.step.monitor_computation as mc
+
+
+class DummyGPU:
+    def __init__(self):
+        self.calls = 0
+    def reset(self):
+        pass
+    def collect(self, **kw):
+        self.calls += 1
+        return {
+            'gpu_utilization': 42,
+            'gpu_memory_used_mb': 1,
+            'gpu_memory_total_mb': 2,
+            'gpu_memory_percent': 50,
+        }
+    def get_summary(self):
+        return {'avg_utilization': 42, 'avg_memory_percent': 50, 'count': self.calls}
+
+
+class DummyMemory:
+    def __init__(self):
+        self.calls = 0
+    def reset(self):
+        pass
+    def collect(self, **kw):
+        self.calls += 1
+        return {'ram_used_mb': 3, 'ram_total_mb': 4, 'ram_percent': 30}
+    def get_summary(self):
+        return {'avg_ram_percent': 30, 'peak_ram_percent': 30, 'count': self.calls}
+
+
+class DummyPower:
+    def __init__(self):
+        self.calls = 0
+    def reset(self):
+        pass
+    def collect(self, interval=None, **kw):
+        self.calls += 1
+        return {
+            'power_usage_watts': 5,
+            'energy_joules': 0,
+            'total_energy_joules': 0,
+            'total_energy_wh': 0,
+        }
+    def get_summary(self):
+        return {
+            'avg_power_watts': 5,
+            'peak_power_watts': 5,
+            'total_energy_wh': 0,
+            'collection_duration_s': self.calls,
+        }
+
+
+def test_monitor_metrics_recorded(monkeypatch, tmp_path):
+    # stub heavy deps
+    monkeypatch.setitem(sys.modules, 'torch', types.ModuleType('torch'))
+    monkeypatch.setitem(sys.modules, 'torch.nn', types.ModuleType('torch.nn'))
+    mpl = types.ModuleType('matplotlib')
+    plt = types.ModuleType('matplotlib.pyplot')
+    monkeypatch.setitem(sys.modules, 'matplotlib', mpl)
+    monkeypatch.setitem(sys.modules, 'matplotlib.pyplot', plt)
+
+    dummy = types.SimpleNamespace(model=object())
+    dummy.train = lambda *a, **k: {}
+
+    up = types.ModuleType('ultralytics')
+    up.YOLO = lambda *a, **k: dummy
+    utils = types.ModuleType('ultralytics.utils')
+    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+    torch_utils.get_flops = lambda *a, **k: 10
+    torch_utils.get_num_params = lambda *a, **k: 20
+    utils.torch_utils = torch_utils
+    up.utils = utils
+
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
+
+    import main
+    import pipeline.pruning_pipeline as pp
+    monkeypatch.setattr(pp, 'YOLO', up.YOLO, raising=False)
+    monkeypatch.setattr(pp, 'get_flops', torch_utils.get_flops, raising=False)
+    monkeypatch.setattr(pp, 'get_num_params', torch_utils.get_num_params, raising=False)
+
+    monkeypatch.setattr(mc, 'GPUMetric', DummyGPU)
+    monkeypatch.setattr(mc, 'MemoryMetric', DummyMemory)
+    monkeypatch.setattr(mc, 'PowerMetric', DummyPower)
+
+    cfg = main.TrainConfig(baseline_epochs=1, finetune_epochs=0, batch_size=1, ratios=[0])
+    pipeline, _ = main.execute_pipeline('m.pt', 'd.yaml', None, 0, cfg, tmp_path)
+    comp = pipeline.metrics_mgr.computation
+    assert comp['gpu_utilization'] == 42
+    assert comp['ram_percent'] == 30
+    assert comp['power_usage_watts'] == 5


### PR DESCRIPTION
## Summary
- add MonitorComputationStep for GPU/CPU/power metrics
- export step from `pipeline`
- document workflow updates
- monitor computation around pretrain/finetune in `main.execute_pipeline`
- test recording of computation metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b102d9eec83249dd35ed04ff2f6e2