### PR TITLE
Support dataclass metrics in MetricManager

### DIFF
--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Metric recording utilities for pruning experiments."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, is_dataclass, asdict
 from pathlib import Path
 from typing import Any, Dict, List
 import csv
@@ -49,6 +49,13 @@ class MetricManager:
 
     def record_training(self, metrics: Dict[str, Any]) -> None:
         """Store training metrics filtered by :data:`TRAINING_METRIC_FIELDS`."""
+        if not isinstance(metrics, dict):
+            if is_dataclass(metrics):
+                metrics = asdict(metrics)
+            elif hasattr(metrics, "__dict__"):
+                metrics = metrics.__dict__
+            else:
+                metrics = {}
         for field in TRAINING_METRIC_FIELDS:
             if field in metrics:
                 self.training[field] = metrics[field]

--- a/tests/test_metric_manager.py
+++ b/tests/test_metric_manager.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from helper.metric_manager import MetricManager
+
+
+@dataclass
+class DummyMetrics:
+    mAP: float
+    precision: float = 0.0
+    other: int = 0
+
+
+def test_record_training_with_dataclass():
+    mgr = MetricManager()
+    mgr.record_training(DummyMetrics(mAP=0.5, precision=0.7, other=1))
+    assert mgr.training["mAP"] == 0.5
+    assert mgr.training["precision"] == 0.7
+    assert "other" not in mgr.training


### PR DESCRIPTION
## Summary
- allow `MetricManager.record_training` to handle dataclass or object metrics
- add regression test for dataclass metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b17455b8c83249635873fa6ccaf3f