### PR TITLE
Add seaborn heatmap plotting

### DIFF
--- a/helper/experiment_manager.py
+++ b/helper/experiment_manager.py
@@ -101,6 +101,7 @@ class ExperimentManager:
         try:
             import matplotlib.pyplot as plt  # type: ignore
             import numpy as np  # type: ignore
+            import seaborn as sns  # type: ignore
         except ImportError:
             return
         methods = sorted({r["method"] for r in self.results})
@@ -113,12 +114,16 @@ class ExperimentManager:
             if val is not None:
                 matrix[i, j] = val
         plt.figure()
-        im = plt.imshow(matrix, aspect="auto", origin="lower")
-        plt.xticks(range(len(methods)), methods, rotation=45)
-        plt.yticks(range(len(ratios)), [str(r) for r in ratios])
+        sns.heatmap(
+            matrix,
+            annot=True,
+            cmap="YlGnBu",
+            xticklabels=methods,
+            yticklabels=[str(r) for r in ratios],
+            cbar_kws={"label": metric},
+        )
         plt.xlabel("method")
         plt.ylabel("ratio")
-        plt.colorbar(im, label=metric)
         plt.tight_layout()
         filename = metric.replace(".", "_") + "_heatmap.png"
         plt.savefig(self.workdir / filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ py-cpuinfo
 pandas>=1.1.4
 ultralytics-thop>=2.0.0
 ultralytics>=8.0.0
+seaborn>=0.12.0

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -15,7 +15,7 @@ def test_compare_pruning_methods_without_matplotlib(monkeypatch, tmp_path):
     real_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "matplotlib.pyplot":
+        if name in {"matplotlib.pyplot", "seaborn"}:
             raise ImportError
         return real_import(name, globals, locals, fromlist, level)
 
@@ -32,7 +32,7 @@ def test_plot_functions_without_matplotlib(monkeypatch, tmp_path):
     real_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "matplotlib.pyplot":
+        if name in {"matplotlib.pyplot", "seaborn"}:
             raise ImportError
         return real_import(name, globals, locals, fromlist, level)
 


### PR DESCRIPTION
## Summary
- use seaborn for experiment heatmaps
- require seaborn
- update heatmap tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b4739a69c8324867d5232c799d22d