### PR TITLE
Fix metric extraction for numpy floats

### DIFF
--- a/helper/experiment_manager.py
+++ b/helper/experiment_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List
+import numbers
 
 
 class ExperimentManager:
@@ -64,7 +65,7 @@ class ExperimentManager:
                 value = value[p]
             else:
                 return None
-        if isinstance(value, (int, float)):
+        if isinstance(value, numbers.Number):
             return float(value)
         return None
 

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -2,6 +2,7 @@ import builtins
 import os
 import sys
 import types
+import numpy as np
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -40,3 +41,9 @@ def test_plot_functions_without_matplotlib(monkeypatch, tmp_path):
 
     mgr.plot_line("training.mAP")
     mgr.plot_heatmap("training.mAP")
+
+
+def test_extract_metric_numpy_float(tmp_path):
+    mgr = ExperimentManager("yolo", workdir=tmp_path)
+    data = {"training": {"score": np.float32(0.75)}}
+    assert mgr._extract_metric(data, "training.score") == 0.75


### PR DESCRIPTION
## Summary
- handle numpy numeric types in ExperimentManager
- test extracting metrics stored as numpy.float32

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b488546dc8324a549578cf5a2a090