### PR TITLE
Add file handler helper and test log file creation

### DIFF
--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -1,7 +1,13 @@
 """Helper utilities for pruning experiments."""
 
-from .logger import Logger, get_logger
+from .logger import Logger, get_logger, add_file_handler
 from .metric_manager import MetricManager
 from .experiment_manager import ExperimentManager
 
-__all__ = ["Logger", "get_logger", "MetricManager", "ExperimentManager"]
+__all__ = [
+    "Logger",
+    "get_logger",
+    "add_file_handler",
+    "MetricManager",
+    "ExperimentManager",
+]

--- a/helper/logger.py
+++ b/helper/logger.py
@@ -40,6 +40,15 @@ class Logger:
         self.logger.setLevel(level)
 
 
+def add_file_handler(logger: Logger, log_file: str) -> None:
+    """Attach a :class:`logging.FileHandler` to ``logger`` if missing."""
+    if not any(isinstance(h, logging.FileHandler) for h in logger.logger.handlers):
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        handler = logging.FileHandler(log_file)
+        handler.setFormatter(formatter)
+        logger.logger.addHandler(handler)
+
+
 def get_logger(
     name: str = "pruning",
     level: int = logging.INFO,

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Iterable, List, Type
 import logging
 
-from helper import ExperimentManager, get_logger, Logger
+from helper import ExperimentManager, get_logger, Logger, add_file_handler
 from pipeline import PruningPipeline, MonitorComputationStep
 from prune_methods import (
     BasePruningMethod,
@@ -65,7 +65,7 @@ def execute_pipeline(
     if logger is None:
         logger = get_logger(log_file=str(log_file))
     else:
-        get_logger(log_file=str(log_file))
+        add_file_handler(logger, str(log_file))
     pipeline = PruningPipeline(model_path, data=data, workdir=str(workdir), logger=logger)
     pipeline.load_model()
     if method_cls is not None:

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import main
+
+
+def test_log_file_created_with_logger(tmp_path, monkeypatch):
+    class DummyPipeline:
+        def __init__(self, *a, **k):
+            self.model = types.SimpleNamespace(model=object())
+            self.metrics_mgr = types.SimpleNamespace(to_csv=lambda p: Path(p))
+
+        def load_model(self):
+            pass
+
+        def calc_initial_stats(self):
+            pass
+
+        def pretrain(self, **kw):
+            pass
+
+        def analyze_structure(self):
+            pass
+
+        def generate_pruning_mask(self, ratio):
+            pass
+
+        def apply_pruning(self):
+            pass
+
+        def reconfigure_model(self):
+            pass
+
+        def calc_pruned_stats(self):
+            pass
+
+        def finetune(self, **kw):
+            pass
+
+        def visualize_results(self):
+            pass
+
+        def save_pruning_results(self, path):
+            pass
+
+        def save_metrics_csv(self, path):
+            return Path(path)
+
+    monkeypatch.setattr(main, "PruningPipeline", DummyPipeline)
+    logger = main.get_logger()
+    cfg = main.TrainConfig(baseline_epochs=0, finetune_epochs=0, batch_size=1, ratios=[0])
+    main.execute_pipeline("m", "d", None, 0, cfg, tmp_path, logger=logger)
+    assert (tmp_path / "pipeline.log").exists()


### PR DESCRIPTION
## Summary
- add `add_file_handler` utility to helper.logger
- expose it via helper package
- use the utility in `execute_pipeline` when a logger is provided
- add test ensuring a log file is created when passing a logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b4ad088948324bbc0eb11b785b0a6