### PR TITLE
Improve compare_pruning_methods plotting

### DIFF
--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -25,6 +25,38 @@ def test_compare_pruning_methods_without_matplotlib(monkeypatch, tmp_path):
     mgr.compare_pruning_methods()  # Should handle missing matplotlib gracefully
 
 
+def test_compare_pruning_methods_multiple_lines(monkeypatch, tmp_path):
+    mgr = ExperimentManager("yolo", workdir=tmp_path)
+    mgr.add_result("m1", 0.1, {"mAP": 0.2})
+    mgr.add_result("m1", 0.2, {"mAP": 0.3})
+    mgr.add_result("m2", 0.1, {"mAP": 0.25})
+
+    records = []
+
+    dummy = types.SimpleNamespace(
+        figure=lambda: None,
+        title=lambda *a, **k: None,
+        xlabel=lambda *a, **k: None,
+        ylabel=lambda *a, **k: None,
+        legend=lambda *a, **k: None,
+        tight_layout=lambda: None,
+        savefig=lambda *a, **k: None,
+        close=lambda *a, **k: None,
+    )
+
+    def plot(x, y, marker=None, label=None):
+        records.append({"x": x, "y": y, "label": label})
+
+    dummy.plot = plot
+
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", dummy)
+
+    mgr.compare_pruning_methods()
+
+    assert len(records) == 2
+    assert {r["label"] for r in records} == {"m1", "m2"}
+
+
 def test_plot_functions_without_matplotlib(monkeypatch, tmp_path):
     mgr = ExperimentManager("yolo", workdir=tmp_path)
     mgr.add_result("m1", 0.1, {"training": {"mAP": 0.2}})


### PR DESCRIPTION
## Summary
- group results per method in compare_pruning_methods
- label each method's line when plotting comparison
- test that multiple methods produce multiple lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b4bdcc6c08324b6baedec9d23a78a