### PR TITLE
Enable training plots by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    TrainStep("pretrain", epochs=1, plots=False),
+    TrainStep("pretrain", epochs=1, plots=True),
     AnalyzeModelStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
@@ -120,13 +120,13 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    TrainStep("pretrain", epochs=1, plots=False),
+    TrainStep("pretrain", epochs=1, plots=True),
     AnalyzeModelStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     ReconfigureModelStep(),
     CalcStatsStep("pruned"),
-    TrainStep("finetune", epochs=3, plots=False),
+    TrainStep("finetune", epochs=3, plots=True),
 ]
 
 pipeline = PruningPipeline(

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -59,7 +59,7 @@ A typical set of steps might look as follows:
 1. `LoadModelStep()`
 2. `CalcStatsStep("initial")`
 3. `MonitorComputationStep("pretrain")` *(start before training)*
-4. `TrainStep("pretrain", epochs=1, plots=False)`
+4. `TrainStep("pretrain", epochs=1, plots=True)`
 5. `MonitorComputationStep("pretrain")` *(stop after training)*
 6. `AnalyzeModelStep()`
 7. `GenerateMasksStep(ratio=0.2)`
@@ -67,7 +67,7 @@ A typical set of steps might look as follows:
 9. `ReconfigureModelStep()`
 10. `CalcStatsStep("pruned")`
 11. `MonitorComputationStep("finetune")` *(start before training)*
-12. `TrainStep("finetune", epochs=3, plots=False)`
+12. `TrainStep("finetune", epochs=3, plots=True)`
 13. `MonitorComputationStep("finetune")` *(stop after training)*
 
 `PruningPipeline` will execute them sequentially, passing the same context object to each. Statistics and metrics are accumulated inside `context` and can be retrieved at the end via `pipeline.record_metrics()` or directly from `context.metrics`.

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -81,7 +81,7 @@ class PruningPipeline(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Pretraining model")
-        train_kwargs.setdefault("plots", False)
+        train_kwargs.setdefault("plots", True)
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
@@ -146,7 +146,7 @@ class PruningPipeline(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Finetuning pruned model")
-        train_kwargs.setdefault("plots", False)
+        train_kwargs.setdefault("plots", True)
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -10,7 +10,7 @@ class TrainStep(PipelineStep):
     """Train or finetune the model using ``YOLO.train``.
 
     Parameters passed via ``train_kwargs`` are forwarded to ``YOLO.train``. By
-    default plotting is disabled unless ``plots=True`` is specified.
+    default plotting is enabled unless ``plots=False`` is specified.
     """
 
     def __init__(self, phase: str, **train_kwargs: Any) -> None:
@@ -21,7 +21,7 @@ class TrainStep(PipelineStep):
         if context.model is None:
             raise ValueError("Model is not loaded")
         context.logger.info("Training model (%s)", self.phase)
-        self.train_kwargs.setdefault("plots", False)
+        self.train_kwargs.setdefault("plots", True)
         metrics = context.model.train(data=context.data, **self.train_kwargs)
         context.metrics_mgr.record_training(metrics or {})
         context.metrics[self.phase] = metrics or {}


### PR DESCRIPTION
## Summary
- enable train plots by default during pipeline execution
- show plot usage in documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684beae494c0832494323633415697c2