### PR TITLE
Save pruning results to pt file

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ def execute_pipeline(
             mgr = pipeline.metrics_mgr = MetricManager()
         monitor.stop(mgr)
     pipeline.visualize_results()
-    pipeline.save_pruning_results(workdir / "results")
+    pipeline.save_pruning_results(workdir / "results.pt")
     csv_path = pipeline.save_metrics_csv(workdir / "metrics.csv")
     return pipeline, csv_path
 


### PR DESCRIPTION
## Summary
- save pruning results to a `.pt` file when running the pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bead734c08324bf6fc55e1fe51f35