### PR TITLE
Add CLI metric plotting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Each run directory will contain a `pipeline.log` file capturing detailed
 training and pruning output for the selected ratio.
 
 Use `--device` to select the training device (defaults to `cuda:0`).
+Use `--plot-metrics` to specify which metrics are visualized after the runs.
 
 ## Panduan Setup Lingkungan (Bahasa Indonesia)
 

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -44,6 +44,7 @@ def test_main_help_shows_options(capsys, monkeypatch):
         '--batch-size',
         '--ratios',
         '--device',
+        '--plot-metrics',
     ]:
         assert opt in help_text
 


### PR DESCRIPTION
## Summary
- allow ExperimentRunner to specify metrics to plot
- add `--plot-metrics` CLI option in `main.py`
- document the new CLI option in README
- update test_main_help to verify `--plot-metrics`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bf443bb5c83249f1d77ec25a25785