### PR TITLE
Include computation metrics in pipeline outputs

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -154,13 +154,12 @@ class PruningPipeline(BasePruningPipeline):
         return metrics or {}
 
     def record_metrics(self) -> Dict[str, Any]:
-        """Return a dictionary containing training and pruning statistics."""
+        """Return a dictionary containing all recorded metrics."""
         self.logger.info("Recording metrics")
-        return {
-            "initial": self.initial_stats,
-            "pruned": self.pruned_stats,
-            "training": self.metrics,
-        }
+        data = self.metrics_mgr.as_dict()
+        data["initial"] = self.initial_stats
+        data["pruned"] = self.pruned_stats
+        return data
 
     def save_metrics_csv(self, path: str | Path) -> Path:
         """Persist recorded metrics to ``path`` using :class:`MetricManager`."""

--- a/tests/test_monitor_step.py
+++ b/tests/test_monitor_step.py
@@ -99,3 +99,8 @@ def test_monitor_metrics_recorded(monkeypatch, tmp_path):
     assert comp['gpu_utilization'] == 42
     assert comp['ram_percent'] == 30
     assert comp['power_usage_watts'] == 5
+    metrics = pipeline.record_metrics()
+    assert 'computation' in metrics
+    assert metrics['computation']['gpu_utilization'] == 42
+    assert metrics['computation']['ram_percent'] == 30
+    assert metrics['computation']['power_usage_watts'] == 5


### PR DESCRIPTION
## Summary
- record full metric manager info when gathering pipeline results
- test that computation metrics show up in `record_metrics`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684bff3852748324879fff6d087431a8