### PR TITLE
Add extended pruning metrics and RAM tracking

### DIFF
--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -4,6 +4,7 @@ from .logger import Logger, get_logger, add_file_handler
 from .metric_manager import MetricManager
 from .experiment_manager import ExperimentManager
 from .heatmap_visualizer import plot_metric_heatmaps
+from .model_stats import count_filters, model_size_mb
 
 __all__ = [
     "Logger",
@@ -12,4 +13,6 @@ __all__ = [
     "MetricManager",
     "ExperimentManager",
     "plot_metric_heatmaps",
+    "count_filters",
+    "model_size_mb",
 ]

--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -28,6 +28,7 @@ COMPUTATION_METRIC_FIELDS = [
     "ram_used_mb",
     "ram_total_mb",
     "ram_percent",
+    "avg_ram_used_mb",
     "power_usage_watts",
 ]
 
@@ -35,6 +36,7 @@ PRUNING_METRIC_FIELDS = {
     "parameters": ["original", "pruned", "reduction", "reduction_percent"],
     "flops": ["original", "pruned", "reduction", "reduction_percent"],
     "filters": ["original", "pruned", "reduction", "reduction_percent"],
+    "model_size_mb": ["original", "pruned", "reduction", "reduction_percent"],
     "compression_ratio": None,
 }
 

--- a/helper/model_stats.py
+++ b/helper/model_stats.py
@@ -1,0 +1,40 @@
+"""Utility functions for computing model statistics."""
+from __future__ import annotations
+
+from typing import Any
+
+import logging
+
+try:
+    import torch.nn as nn  # type: ignore
+except Exception:  # pragma: no cover - torch may not be installed
+    nn = None  # type: ignore
+
+
+def count_filters(model: Any) -> int:
+    """Return the total number of convolution filters in ``model``."""
+    total = 0
+    modules = getattr(model, "modules", lambda: [])()
+    for m in modules:
+        if nn is not None and isinstance(m, nn.Conv2d):
+            total += int(getattr(m, "out_channels", 0))
+        else:
+            # Fallback: check for ``out_channels`` attribute
+            if hasattr(m, "out_channels"):
+                total += int(getattr(m, "out_channels", 0))
+    return total
+
+
+def model_size_mb(model: Any) -> float:
+    """Approximate model size in megabytes based on parameters."""
+    size_bytes = 0
+    for p in getattr(model, "parameters", lambda: [])():
+        try:
+            size_bytes += p.numel() * p.element_size()
+        except Exception as exc:  # pragma: no cover - for non-tensor params
+            logging.debug("model_size_mb parameter error: %s", exc)
+            continue
+    return size_bytes / (1024 * 1024)
+
+
+__all__ = ["count_filters", "model_size_mb"]

--- a/pipeline/step/calc_stats.py
+++ b/pipeline/step/calc_stats.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from ultralytics.utils.torch_utils import get_flops, get_num_params
 
+from helper import count_filters, model_size_mb
+
 from ..context import PipelineContext
 from . import PipelineStep
 
@@ -18,28 +20,61 @@ class CalcStatsStep(PipelineStep):
         context.logger.info("Calculating %s statistics", self.dest)
         params = get_num_params(context.model.model)
         flops = get_flops(context.model.model)
-        stats = {"parameters": params, "flops": flops}
+        filters = count_filters(context.model.model)
+        size_mb = model_size_mb(context.model.model)
+        stats = {
+            "parameters": params,
+            "flops": flops,
+            "filters": filters,
+            "model_size_mb": size_mb,
+        }
         if self.dest == "initial":
             context.initial_stats = stats
-            context.metrics_mgr.record_pruning({
-                "parameters": {"original": params},
-                "flops": {"original": flops},
-            })
+            context.metrics_mgr.record_pruning(
+                {
+                    "parameters": {"original": params},
+                    "flops": {"original": flops},
+                    "filters": {"original": filters},
+                    "model_size_mb": {"original": size_mb},
+                }
+            )
         else:
             context.pruned_stats = stats
             orig_params = context.initial_stats.get("parameters", params)
             orig_flops = context.initial_stats.get("flops", flops)
-            context.metrics_mgr.record_pruning({
-                "parameters": {
-                    "pruned": params,
-                    "reduction": orig_params - params,
-                    "reduction_percent": ((orig_params - params) / orig_params * 100) if orig_params else 0,
-                },
-                "flops": {
-                    "pruned": flops,
-                    "reduction": orig_flops - flops,
-                    "reduction_percent": ((orig_flops - flops) / orig_flops * 100) if orig_flops else 0,
-                },
-            })
+            orig_filters = context.initial_stats.get("filters", filters)
+            orig_size = context.initial_stats.get("model_size_mb", size_mb)
+            context.metrics_mgr.record_pruning(
+                {
+                    "parameters": {
+                        "pruned": params,
+                        "reduction": orig_params - params,
+                        "reduction_percent": ((orig_params - params) / orig_params * 100)
+                        if orig_params
+                        else 0,
+                    },
+                    "flops": {
+                        "pruned": flops,
+                        "reduction": orig_flops - flops,
+                        "reduction_percent": ((orig_flops - flops) / orig_flops * 100)
+                        if orig_flops
+                        else 0,
+                    },
+                    "filters": {
+                        "pruned": filters,
+                        "reduction": orig_filters - filters,
+                        "reduction_percent": ((orig_filters - filters) / orig_filters * 100)
+                        if orig_filters
+                        else 0,
+                    },
+                    "model_size_mb": {
+                        "pruned": size_mb,
+                        "reduction": orig_size - size_mb,
+                        "reduction_percent": ((orig_size - size_mb) / orig_size * 100)
+                        if orig_size
+                        else 0,
+                    },
+                }
+            )
 
 __all__ = ["CalcStatsStep"]

--- a/tests/test_calc_stats_step.py
+++ b/tests/test_calc_stats_step.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_calc_stats_records_filters_and_size(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ultralytics", types.ModuleType("ultralytics"))
+    utils = types.ModuleType("ultralytics.utils")
+    torch_utils = types.ModuleType("ultralytics.utils.torch_utils")
+    torch_utils.get_flops = lambda *a, **k: 20
+    torch_utils.get_num_params = lambda *a, **k: 10
+    monkeypatch.setitem(sys.modules, "ultralytics.utils", utils)
+    monkeypatch.setitem(sys.modules, "ultralytics.utils.torch_utils", torch_utils)
+
+    # stub prune_methods.base to avoid torch dependency
+    base_mod = types.ModuleType("prune_methods.base")
+    class BasePruningMethod:  # pragma: no cover - placeholder
+        pass
+    base_mod.BasePruningMethod = BasePruningMethod
+    monkeypatch.setitem(sys.modules, "prune_methods.base", base_mod)
+
+    from pipeline.step.calc_stats import CalcStatsStep
+    from pipeline.context import PipelineContext
+
+    dummy_model = types.SimpleNamespace(model=types.SimpleNamespace())
+    ctx = PipelineContext(model_path="m", data="d")
+    ctx.model = dummy_model
+
+    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params", lambda m: 10, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 20, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 3, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.model_size_mb", lambda m: 1.5, raising=False)
+
+    step = CalcStatsStep("initial")
+    step.run(ctx)
+
+    assert ctx.metrics_mgr.pruning["filters"]["original"] == 3
+    assert ctx.metrics_mgr.pruning["model_size_mb"]["original"] == 1.5

--- a/tests/test_metrics_csv.py
+++ b/tests/test_metrics_csv.py
@@ -43,3 +43,4 @@ def test_metrics_csv_created(tmp_path):
     header = csv_path.read_text().splitlines()[0]
     assert 'training.mAP' in header
     assert 'pruning.parameters.original' in header
+    assert 'pruning.model_size_mb.original' in header

--- a/tests/test_monitor_step.py
+++ b/tests/test_monitor_step.py
@@ -98,9 +98,11 @@ def test_monitor_metrics_recorded(monkeypatch, tmp_path):
     comp = pipeline.metrics_mgr.computation
     assert comp['gpu_utilization'] == 42
     assert comp['ram_percent'] == 30
+    assert comp['avg_ram_used_mb'] == 3
     assert comp['power_usage_watts'] == 5
     metrics = pipeline.record_metrics()
     assert 'computation' in metrics
     assert metrics['computation']['gpu_utilization'] == 42
     assert metrics['computation']['ram_percent'] == 30
+    assert metrics['computation']['avg_ram_used_mb'] == 3
     assert metrics['computation']['power_usage_watts'] == 5


### PR DESCRIPTION
## Summary
- support computing total filters and model size
- calculate and record these stats via pipeline
- track average RAM usage during computation monitoring
- add helper utilities for model stats
- cover new behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c02832d3c8324bc78158fdaf6564f