### PR TITLE
Add metrics dataframe loader and default heatmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ df = pd.DataFrame({
 plot_metric_heatmaps(df, ["FLOPsReduction"], "plots")
 ```
 
+Metrics recorded by experiment runs can also be visualised directly. Use
+``load_metrics_dataframe`` to read all ``metrics.csv`` files from a directory and
+then create heatmaps for common metrics:
+
+```python
+from helper import load_metrics_dataframe, plot_metric_heatmaps, DEFAULT_METRICS
+
+df = load_metrics_dataframe("runs/experiments")
+plot_metric_heatmaps(df, DEFAULT_METRICS, "plots")
+```
+
 
 ## Batch training script
 

--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -3,7 +3,12 @@
 from .logger import Logger, get_logger, add_file_handler
 from .metric_manager import MetricManager
 from .experiment_manager import ExperimentManager
-from .heatmap_visualizer import plot_metric_heatmaps
+from .heatmap_visualizer import (
+    plot_metric_heatmaps,
+    plot_default_metric_heatmaps,
+    DEFAULT_METRICS,
+)
+from .metrics_loader import load_metrics_dataframe
 from .model_stats import count_filters, model_size_mb
 
 __all__ = [
@@ -13,6 +18,9 @@ __all__ = [
     "MetricManager",
     "ExperimentManager",
     "plot_metric_heatmaps",
+    "plot_default_metric_heatmaps",
+    "DEFAULT_METRICS",
+    "load_metrics_dataframe",
     "count_filters",
     "model_size_mb",
 ]

--- a/helper/heatmap_visualizer.py
+++ b/helper/heatmap_visualizer.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 
+DEFAULT_METRICS = [
+    "pruning.flops.reduction_percent",
+    "pruning.parameters.reduction_percent",
+    "pruning.model_size_mb.reduction_percent",
+]
+
 import pandas as pd
 
 
@@ -44,3 +50,15 @@ def plot_metric_heatmaps(df: pd.DataFrame, metrics: List[str], output_dir: str) 
         filename = f"{safe_metric}_heatmap.png"
         plt.savefig(out_path / filename)
         plt.close()
+
+
+def plot_default_metric_heatmaps(df: pd.DataFrame, output_dir: str) -> None:
+    """Generate heatmaps for :data:`DEFAULT_METRICS`."""
+    plot_metric_heatmaps(df, DEFAULT_METRICS, output_dir)
+
+
+__all__ = [
+    "plot_metric_heatmaps",
+    "plot_default_metric_heatmaps",
+    "DEFAULT_METRICS",
+]

--- a/helper/metrics_loader.py
+++ b/helper/metrics_loader.py
@@ -1,0 +1,43 @@
+"""Load metrics CSV files from experiment runs into a DataFrame."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+def load_metrics_dataframe(root: str | Path) -> pd.DataFrame:
+    """Return DataFrame with metrics from all ``metrics.csv`` files under ``root``.
+
+    The DataFrame includes ``pruning.method`` and ``pruning.ratio`` columns
+    inferred from the parent directory name of each CSV. Any metrics recorded in
+    the CSV are preserved as additional columns.
+    """
+    root = Path(root)
+    records = []
+    for csv_path in root.rglob("metrics.csv"):
+        try:
+            df = pd.read_csv(csv_path)
+        except Exception:
+            continue
+        if df.empty:
+            continue
+        row = df.iloc[0].to_dict()
+        run_name = csv_path.parent.name
+        method = None
+        ratio = None
+        if "_r" in run_name:
+            method, ratio_str = run_name.rsplit("_r", 1)
+            ratio_str = ratio_str.replace("_", ".")
+            try:
+                ratio = float(ratio_str)
+            except ValueError:
+                ratio = None
+        row["pruning.method"] = method
+        row["pruning.ratio"] = ratio
+        records.append(row)
+    return pd.DataFrame(records)
+
+__all__ = ["load_metrics_dataframe"]

--- a/tests/test_metrics_loader.py
+++ b/tests/test_metrics_loader.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pandas as pd
+import importlib
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from helper import load_metrics_dataframe
+from helper.heatmap_visualizer import plot_default_metric_heatmaps, DEFAULT_METRICS
+
+
+def test_load_metrics_dataframe(tmp_path):
+    run1 = tmp_path / "MethodA_r0.1"
+    run1.mkdir()
+    (run1 / "metrics.csv").write_text("a,b\n1,2\n")
+
+    run2 = tmp_path / "MethodB_r0_2"
+    run2.mkdir()
+    (run2 / "metrics.csv").write_text("a,b\n3,4\n")
+
+    df = load_metrics_dataframe(tmp_path)
+    assert set(df["pruning.method"]) == {"MethodA", "MethodB"}
+    assert set(df["pruning.ratio"]) == {0.1, 0.2}
+    assert set(df.columns) >= {"a", "b", "pruning.method", "pruning.ratio"}
+
+
+def test_plot_default_metric_heatmaps(tmp_path, monkeypatch):
+    calls = []
+
+    def fake(df, metrics, output_dir):
+        calls.append((list(metrics), Path(output_dir)))
+
+    monkeypatch.setattr(
+        "helper.heatmap_visualizer.plot_metric_heatmaps", fake, raising=False
+    )
+
+    df = pd.DataFrame({
+        "pruning.method": ["m1", "m1", "m2", "m2"],
+        "pruning.ratio": [0.1, 0.2, 0.1, 0.2],
+        DEFAULT_METRICS[0]: [1, 2, 3, 4],
+        DEFAULT_METRICS[1]: [5, 6, 7, 8],
+        DEFAULT_METRICS[2]: [9, 10, 11, 12],
+    })
+
+    plot_default_metric_heatmaps(df, tmp_path)
+
+    assert calls == [(DEFAULT_METRICS, tmp_path)]


### PR DESCRIPTION
## Summary
- provide helper to load metrics.csv files into a dataframe
- expose helper via package __init__
- extend heatmap utilities with defaults and wrapper
- document how to load and visualise metrics
- test new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c07629fb0832493b17ff322256686