### PR TITLE
Enable default metrics visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ Each run directory will contain a `pipeline.log` file capturing detailed
 training and pruning output for the selected ratio.
 
 Use `--device` to select the training device (defaults to `cuda:0`).
-Use `--plot-metrics` to specify which metrics are visualized after the runs.
+The script automatically visualizes several metrics after all runs:
+`FLOPsReduction`, `FilterReduction`, `TotalRuntimeMinutes`, `Recall`,
+`mAP50_95`, `ParameterReduction`, `Precision`, `mAP`, `ModelSizeMB` and
+`AvgMemoryUsageMB`.
 
 ## Panduan Setup Lingkungan (Bahasa Indonesia)
 

--- a/main.py
+++ b/main.py
@@ -30,6 +30,20 @@ METHODS_MAP = {
     "random": RandomPruningMethod,
 }
 
+# Default metrics visualized when no custom list is provided
+DEFAULT_PLOT_METRICS = [
+    "pruning.flops.reduction_percent",
+    "pruning.filters.reduction_percent",
+    "computation.total_time_minutes",
+    "training.recall",
+    "training.mAP50_95",
+    "pruning.parameters.reduction_percent",
+    "training.precision",
+    "training.mAP",
+    "pruning.model_size_mb.reduction_percent",
+    "computation.avg_ram_used_mb",
+]
+
 
 def safe_name(value: str) -> str:
     """Return a filesystem-friendly version of ``value``."""
@@ -144,7 +158,7 @@ class ExperimentRunner:
         self.resume = resume
         self.logger = logger or get_logger()
         self.manager = ExperimentManager(Path(model_path).stem, workdir)
-        self.metrics = metrics or ["training.mAP"]
+        self.metrics = metrics or DEFAULT_PLOT_METRICS
 
     def run(self) -> None:
         """Execute all pruning experiments."""
@@ -227,12 +241,6 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=[0.2, 0.4, 0.6, 0.8],
         help="Pruning ratios to evaluate",
-    )
-    parser.add_argument(
-        "--plot-metrics",
-        nargs="+",
-        default=["training.mAP"],
-        help="Metrics to visualize after runs",
     )
     parser.add_argument("--methods", nargs="+", default=list(METHODS_MAP.keys()), help="Pruning methods to evaluate")
     parser.add_argument("--runs-dir", default="experiments", help="Root directory for comparison runs")
@@ -376,7 +384,6 @@ def main() -> None:
         workdir=args.workdir,
         resume=args.resume,
         logger=logger,
-        metrics=args.plot_metrics,
     )
     runner.run()
 

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -44,7 +44,6 @@ def test_main_help_shows_options(capsys, monkeypatch):
         '--batch-size',
         '--ratios',
         '--device',
-        '--plot-metrics',
     ]:
         assert opt in help_text
 


### PR DESCRIPTION
## Summary
- remove `--plot-metrics` option from CLI
- add `DEFAULT_PLOT_METRICS` constant
- plot default metrics automatically
- document default metrics in README
- adjust CLI help test

## Testing
- `pip install pandas numpy seaborn pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c105f6e0c83248bdd26835cb58cc1