### PR TITLE
Update metric manager for new YOLO output

### DIFF
--- a/tests/test_metric_manager.py
+++ b/tests/test_metric_manager.py
@@ -16,3 +16,18 @@ def test_record_training_with_dataclass():
     assert mgr.training["mAP"] == 0.5
     assert mgr.training["precision"] == 0.7
     assert "other" not in mgr.training
+
+
+def test_record_training_with_ultralytics_fields():
+    mgr = MetricManager()
+    metrics = {
+        "metrics/precision": 0.1,
+        "metrics/recall": 0.2,
+        "metrics/mAP50": 0.3,
+        "metrics/mAP50-95": 0.4,
+    }
+    mgr.record_training(metrics)
+    assert mgr.training["precision"] == 0.1
+    assert mgr.training["recall"] == 0.2
+    assert mgr.training["mAP"] == 0.3
+    assert mgr.training["mAP50_95"] == 0.4

--- a/tests/test_metrics_csv.py
+++ b/tests/test_metrics_csv.py
@@ -14,7 +14,12 @@ sys.modules['matplotlib'] = mpl
 sys.modules['matplotlib.pyplot'] = plt
 
 dummy = types.SimpleNamespace(model=object())
-dummy.train = lambda *a, **k: {'mAP': 0.1}
+dummy.train = lambda *a, **k: {
+    'metrics/precision': 0.1,
+    'metrics/recall': 0.2,
+    'metrics/mAP50': 0.3,
+    'metrics/mAP50-95': 0.4,
+}
 
 up = types.ModuleType('ultralytics')
 up.YOLO = lambda *a, **k: dummy
@@ -42,5 +47,8 @@ def test_metrics_csv_created(tmp_path):
     assert csv_path.exists()
     header = csv_path.read_text().splitlines()[0]
     assert 'training.mAP' in header
+    assert 'training.mAP50_95' in header
+    assert 'training.precision' in header
+    assert 'training.recall' in header
     assert 'pruning.parameters.original' in header
     assert 'pruning.model_size_mb.original' in header


### PR DESCRIPTION
## Summary
- support new Ultralytics training keys (e.g. `metrics/precision`)
- convert them to canonical names in `MetricManager`
- adjust tests to mimic new Ultralytics output

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c1cead4108324a018a4a0b8b2aacc