### PR TITLE
Add torch pruning methods

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,12 +22,16 @@ from prune_methods import (
     BasePruningMethod,
     L1NormPruningMethod,
     RandomPruningMethod,
+    DepGraphPruningMethod,
+    TorchPruningRandomMethod,
 )
 
 
 METHODS_MAP = {
     "l1": L1NormPruningMethod,
     "random": RandomPruningMethod,
+    "depgraph": DepGraphPruningMethod,
+    "tp_random": TorchPruningRandomMethod,
 }
 
 # Default metrics visualized when no custom list is provided

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -130,6 +130,8 @@ class PruningPipeline(BasePruningPipeline):
         """Reconfigure the model after pruning if necessary."""
         if self.pruning_method is None:
             raise NotImplementedError
+        if not getattr(self.pruning_method, "requires_reconfiguration", True):
+            return
         self.logger.info("Reconfiguring pruned model")
         if self.model is not None:
             self.reconfigurator.reconfigure_model(self.model)

--- a/prune_methods/__init__.py
+++ b/prune_methods/__init__.py
@@ -3,8 +3,12 @@
 from .base import BasePruningMethod
 from .l1_norm import L1NormPruningMethod
 from .random_pruning import RandomPruningMethod
+from .depgraph_pruning import DepGraphPruningMethod
+from .torch_pruning_simple import TorchPruningRandomMethod
 __all__ = [
     "BasePruningMethod",
     "L1NormPruningMethod",
     "RandomPruningMethod",
+    "DepGraphPruningMethod",
+    "TorchPruningRandomMethod",
 ]

--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -26,6 +26,8 @@ from helper import get_logger, Logger
 class BasePruningMethod(abc.ABC):
     """Abstract interface for pruning algorithms."""
 
+    requires_reconfiguration: bool = True
+
     def __init__(self, model: Any, workdir: str | Path = "runs/pruning") -> None:
         self.model = model
         self.workdir = Path(workdir)

--- a/prune_methods/depgraph_pruning.py
+++ b/prune_methods/depgraph_pruning.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch_pruning as tp
+
+from .base import BasePruningMethod
+
+
+class DepGraphPruningMethod(BasePruningMethod):
+    """Pruning using ``torch-pruning`` with a dependency graph."""
+
+    requires_reconfiguration = False
+
+    def __init__(self, model: Any, workdir: str = "runs/pruning") -> None:
+        super().__init__(model, workdir)
+        self.example_inputs = torch.randn(1, 3, 640, 640)
+        self.pruner: tp.pruner.algorithms.BasePruner | None = None
+
+    def analyze_model(self) -> None:
+        self.DG = tp.DependencyGraph().build_dependency(self.model, self.example_inputs)
+
+    def generate_pruning_mask(self, ratio: float) -> None:
+        importance = tp.pruner.importance.MagnitudeImportance(p=2)
+        self.pruner = tp.pruner.algorithms.BasePruner(
+            self.model,
+            example_inputs=self.example_inputs,
+            importance=importance,
+            pruning_ratio=ratio,
+            iterative_steps=1,
+        )
+
+    def apply_pruning(self) -> None:
+        if self.pruner is None:
+            raise RuntimeError("generate_pruning_mask must be called first")
+        self.pruner.step()
+

--- a/prune_methods/torch_pruning_simple.py
+++ b/prune_methods/torch_pruning_simple.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch_pruning as tp
+
+from .base import BasePruningMethod
+
+
+class TorchPruningRandomMethod(BasePruningMethod):
+    """Prune using ``torch-pruning`` with random importance."""
+
+    requires_reconfiguration = False
+
+    def __init__(self, model: Any, workdir: str = "runs/pruning") -> None:
+        super().__init__(model, workdir)
+        self.example_inputs = torch.randn(1, 3, 640, 640)
+        self.pruner: tp.pruner.algorithms.BasePruner | None = None
+
+    def analyze_model(self) -> None:
+        tp.DependencyGraph().build_dependency(self.model, self.example_inputs)
+
+    def generate_pruning_mask(self, ratio: float) -> None:
+        importance = tp.pruner.importance.RandomImportance()
+        self.pruner = tp.pruner.algorithms.BasePruner(
+            self.model,
+            example_inputs=self.example_inputs,
+            importance=importance,
+            pruning_ratio=ratio,
+            iterative_steps=1,
+        )
+
+    def apply_pruning(self) -> None:
+        if self.pruner is None:
+            raise RuntimeError("generate_pruning_mask must be called first")
+        self.pruner.step()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pandas>=1.1.4
 ultralytics-thop>=2.0.0
 ultralytics>=8.0.0
 seaborn>=0.12.0
+torch-pruning>=1.5.2

--- a/tests/test_new_methods_import.py
+++ b/tests/test_new_methods_import.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# stub heavy dependency
+sys.modules.setdefault("torch", types.ModuleType("torch"))
+sys.modules.setdefault("torch.nn", types.ModuleType("torch.nn"))
+sys.modules.setdefault("matplotlib", types.ModuleType("matplotlib"))
+sys.modules.setdefault("matplotlib.pyplot", types.ModuleType("matplotlib.pyplot"))
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+sys.modules.setdefault("torch_pruning", types.ModuleType("torch_pruning"))
+
+
+def test_new_methods_have_flag():
+    mod = __import__("prune_methods", fromlist=["DepGraphPruningMethod", "TorchPruningRandomMethod"])
+    DepGraph = mod.DepGraphPruningMethod
+    Simple = mod.TorchPruningRandomMethod
+    assert DepGraph.requires_reconfiguration is False
+    assert Simple.requires_reconfiguration is False
+


### PR DESCRIPTION
## Summary
- support skipping reconfiguration when pruning method does not need it
- add depgraph-based pruning method and simple torch-pruning random method
- expose new methods in package and CLI
- include torch-pruning in requirements
- test that new pruning methods expose expected flag

## Testing
- `pytest -q tests/test_new_methods_import.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684c1de360088324917733c719ce9624