### PR TITLE
Add advanced pruning methods with lazy imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,9 @@ from prune_methods import (
     RandomPruningMethod,
     DepGraphPruningMethod,
     TorchPruningRandomMethod,
+    IsomorphicPruningMethod,
+    HSICLassoPruningMethod,
+    WeightedHybridPruningMethod,
 )
 
 
@@ -32,6 +35,9 @@ METHODS_MAP = {
     "random": RandomPruningMethod,
     "depgraph": DepGraphPruningMethod,
     "tp_random": TorchPruningRandomMethod,
+    "isomorphic": IsomorphicPruningMethod,
+    "hsic_lasso": HSICLassoPruningMethod,
+    "whc": WeightedHybridPruningMethod,
 }
 
 # Default metrics visualized when no custom list is provided

--- a/prune_methods/__init__.py
+++ b/prune_methods/__init__.py
@@ -1,14 +1,34 @@
-"""Pruning method interfaces and placeholders."""
+"""Lazy import interface for pruning methods."""
 
-from .base import BasePruningMethod
-from .l1_norm import L1NormPruningMethod
-from .random_pruning import RandomPruningMethod
-from .depgraph_pruning import DepGraphPruningMethod
-from .torch_pruning_simple import TorchPruningRandomMethod
+from importlib import import_module
+
 __all__ = [
     "BasePruningMethod",
     "L1NormPruningMethod",
     "RandomPruningMethod",
     "DepGraphPruningMethod",
     "TorchPruningRandomMethod",
+    "IsomorphicPruningMethod",
+    "HSICLassoPruningMethod",
+    "WeightedHybridPruningMethod",
 ]
+
+
+def __getattr__(name: str):
+    if name == "BasePruningMethod":
+        return import_module("prune_methods.base").BasePruningMethod
+    if name == "L1NormPruningMethod":
+        return import_module("prune_methods.l1_norm").L1NormPruningMethod
+    if name == "RandomPruningMethod":
+        return import_module("prune_methods.random_pruning").RandomPruningMethod
+    if name == "DepGraphPruningMethod":
+        return import_module("prune_methods.depgraph_pruning").DepGraphPruningMethod
+    if name == "TorchPruningRandomMethod":
+        return import_module("prune_methods.torch_pruning_simple").TorchPruningRandomMethod
+    if name == "IsomorphicPruningMethod":
+        return import_module("prune_methods.isomorphic_pruning").IsomorphicPruningMethod
+    if name == "HSICLassoPruningMethod":
+        return import_module("prune_methods.hsic_lasso").HSICLassoPruningMethod
+    if name == "WeightedHybridPruningMethod":
+        return import_module("prune_methods.weighted_hybrid").WeightedHybridPruningMethod
+    raise AttributeError(name)

--- a/prune_methods/depgraph_pruning.py
+++ b/prune_methods/depgraph_pruning.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-import torch_pruning as tp
 
 from .base import BasePruningMethod
 
@@ -19,9 +18,11 @@ class DepGraphPruningMethod(BasePruningMethod):
         self.pruner: tp.pruner.algorithms.BasePruner | None = None
 
     def analyze_model(self) -> None:
+        import torch_pruning as tp  # local import to avoid heavy dependency at module load
         self.DG = tp.DependencyGraph().build_dependency(self.model, self.example_inputs)
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        import torch_pruning as tp  # local import
         importance = tp.pruner.importance.MagnitudeImportance(p=2)
         self.pruner = tp.pruner.algorithms.BasePruner(
             self.model,

--- a/prune_methods/hsic_lasso.py
+++ b/prune_methods/hsic_lasso.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""HSIC-Lasso channel pruning implementation."""
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+from torch import nn
+
+from .base import BasePruningMethod
+
+
+class HSICLassoPruningMethod(BasePruningMethod):
+    """Prune channels using HSIC criterion with L1 sparsity."""
+
+    def __init__(self, model: Any, workdir: str = "runs/pruning", gamma: float = 1.0) -> None:
+        super().__init__(model, workdir)
+        self.layers: List[Tuple[nn.Module, str, nn.BatchNorm2d | None]] = []
+        self.layer_data: Dict[int, Tuple[torch.Tensor, torch.Tensor]] = {}
+        self.gamma = gamma
+        self.ratio = 0.0
+
+    def analyze_model(self) -> None:
+        """Collect convolution layers from the first 10 backbone modules."""
+        backbone = list(self.model.model[:10])
+        for module in backbone:
+            for name, m in module.named_modules():
+                if isinstance(m, nn.Conv2d):
+                    parent = module.get_submodule(".".join(name.split(".")[:-1])) if "." in name else module
+                    bn = getattr(parent, "bn", None)
+                    if not isinstance(bn, nn.BatchNorm2d):
+                        bn = None
+                    self.layers.append((parent, name.split(".")[-1], bn))
+
+    # ------------------------------------------------------------------
+    # Data collection helpers
+    # ------------------------------------------------------------------
+    def set_layer_data(self, idx: int, features: torch.Tensor, labels: torch.Tensor) -> None:
+        """Attach feature maps and labels for layer ``idx``."""
+        self.layer_data[idx] = (features, labels)
+
+    # ------------------------------------------------------------------
+    # Pruning logic
+    # ------------------------------------------------------------------
+    def _rbf_kernel(self, X: torch.Tensor) -> torch.Tensor:
+        B = X.shape[0]
+        X = X.view(B, -1)
+        dist = torch.cdist(X, X)
+        K = torch.exp(-self.gamma * dist ** 2)
+        H = torch.eye(B, device=K.device) - 1.0 / B
+        return H @ K @ H
+
+    def _hsic_scores(self, F: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = F.shape
+        Ky = self._rbf_kernel(y.unsqueeze(1))
+        scores = []
+        for j in range(C):
+            Kj = self._rbf_kernel(F[:, j, :, :])
+            scores.append((Kj * Ky).mean())
+        return torch.tensor(scores)
+
+    def generate_pruning_mask(self, ratio: float) -> None:
+        self.ratio = ratio
+        self.masks = []
+        for idx, (parent, attr, _) in enumerate(self.layers):
+            conv = getattr(parent, attr)
+            if idx in self.layer_data:
+                F, y = self.layer_data[idx]
+                scores = self._hsic_scores(F, y)
+            else:
+                scores = conv.weight.data.abs().sum(dim=(1, 2, 3))
+            num_keep = max(int(conv.out_channels * (1 - ratio)), 1)
+            _, order = torch.sort(scores, descending=True)
+            mask = torch.zeros(conv.out_channels, dtype=torch.bool)
+            mask[order[:num_keep]] = True
+            self.masks.append(mask)
+
+    def apply_pruning(self) -> None:
+        for (parent, attr, bn), mask in zip(self.layers, self.masks):
+            conv = getattr(parent, attr)
+            keep_idx = mask.nonzero(as_tuple=False).squeeze(1)
+            if len(keep_idx) == conv.out_channels:
+                continue
+            new_conv = nn.Conv2d(
+                conv.in_channels,
+                len(keep_idx),
+                kernel_size=conv.kernel_size,
+                stride=conv.stride,
+                padding=conv.padding,
+                dilation=conv.dilation,
+                groups=conv.groups,
+                bias=conv.bias is not None,
+                padding_mode=conv.padding_mode,
+            )
+            new_conv.weight.data = conv.weight.data[keep_idx].clone()
+            if conv.bias is not None:
+                new_conv.bias.data = conv.bias.data[keep_idx].clone()
+            setattr(parent, attr, new_conv)
+            if bn is not None:
+                new_bn = nn.BatchNorm2d(len(keep_idx))
+                new_bn.weight.data = bn.weight.data[keep_idx].clone()
+                new_bn.bias.data = bn.bias.data[keep_idx].clone()
+                new_bn.running_mean = bn.running_mean[keep_idx].clone()
+                new_bn.running_var = bn.running_var[keep_idx].clone()
+                setattr(parent, "bn", new_bn)

--- a/prune_methods/isomorphic_pruning.py
+++ b/prune_methods/isomorphic_pruning.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Isomorphic pruning method based on dependency graphs."""
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from .base import BasePruningMethod
+
+
+class IsomorphicPruningMethod(BasePruningMethod):
+    """Pruning that preserves layer shapes via ``torch-pruning``."""
+
+    requires_reconfiguration = False
+
+    def __init__(self, model: Any, workdir: str = "runs/pruning", round_to: int | None = None) -> None:
+        super().__init__(model, workdir)
+        self.example_inputs = torch.randn(1, 3, 640, 640)
+        self.round_to = round_to
+        self.pruner = None
+
+    def analyze_model(self) -> None:  # pragma: no cover - heavy dependency
+        import torch_pruning as tp
+        tp.DependencyGraph().build_dependency(self.model, self.example_inputs)
+
+    def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover - heavy dependency
+        import torch_pruning as tp
+        importance = tp.importance.MagnitudeImportance(p=2)
+        self.pruner = tp.MagnitudePruner(
+            self.model,
+            example_inputs=self.example_inputs,
+            importance=importance,
+            global_pruning=True,
+            ch_sparsity=ratio,
+            round_to=self.round_to,
+        )
+
+    def apply_pruning(self) -> None:  # pragma: no cover - heavy dependency
+        if self.pruner is None:
+            raise RuntimeError("generate_pruning_mask must be called first")
+        self.pruner.step()
+        for m in self.model.modules():
+            reparam = getattr(m, "reparam", None)
+            if reparam is not None:
+                try:
+                    reparam.prune_finalize()
+                except Exception:
+                    pass

--- a/prune_methods/torch_pruning_simple.py
+++ b/prune_methods/torch_pruning_simple.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-import torch_pruning as tp
 
 from .base import BasePruningMethod
 
@@ -19,9 +18,11 @@ class TorchPruningRandomMethod(BasePruningMethod):
         self.pruner: tp.pruner.algorithms.BasePruner | None = None
 
     def analyze_model(self) -> None:
+        import torch_pruning as tp
         tp.DependencyGraph().build_dependency(self.model, self.example_inputs)
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        import torch_pruning as tp
         importance = tp.pruner.importance.RandomImportance()
         self.pruner = tp.pruner.algorithms.BasePruner(
             self.model,

--- a/prune_methods/weighted_hybrid.py
+++ b/prune_methods/weighted_hybrid.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Weighted Hybrid Criterion pruning."""
+
+from typing import Any, List, Tuple
+
+import torch
+from torch import nn
+
+from .base import BasePruningMethod
+
+
+class WeightedHybridPruningMethod(BasePruningMethod):
+    """Two-stage pruning: magnitude then redundancy reduction."""
+
+    def __init__(self, model: Any, workdir: str = "runs/pruning", rate_norm: float = 0.5, rate_dist: float = 0.2) -> None:
+        super().__init__(model, workdir)
+        self.layers: List[Tuple[nn.Module, str, nn.BatchNorm2d | None]] = []
+        self.rate_norm = rate_norm
+        self.rate_dist = rate_dist
+        self.ratio = 0.0
+
+    def analyze_model(self) -> None:
+        """Collect convolution layers from the first 10 backbone modules."""
+        backbone = list(self.model.model[:10])
+        for module in backbone:
+            for name, m in module.named_modules():
+                if isinstance(m, nn.Conv2d):
+                    parent = module.get_submodule(".".join(name.split(".")[:-1])) if "." in name else module
+                    bn = getattr(parent, "bn", None)
+                    if not isinstance(bn, nn.BatchNorm2d):
+                        bn = None
+                    self.layers.append((parent, name.split(".")[-1], bn))
+
+    def _pairwise_distance(self, W: torch.Tensor) -> torch.Tensor:
+        norm = W / (W.norm(dim=1, keepdim=True) + 1e-8)
+        sim = torch.abs(torch.mm(norm, norm.t()))
+        return 1 - sim
+
+    def generate_pruning_mask(self, ratio: float) -> None:
+        self.ratio = ratio
+        self.masks = []
+        for parent, attr, _ in self.layers:
+            conv = getattr(parent, attr)
+            scores = conv.weight.data.view(conv.out_channels, -1).norm(p=2, dim=1)
+            num_keep1 = max(int(conv.out_channels * self.rate_norm), 1)
+            _, keep1 = torch.sort(scores, descending=True)
+            keep = keep1[:num_keep1]
+            if len(keep) > 1:
+                D = self._pairwise_distance(conv.weight.data[keep].view(len(keep), -1))
+                remove_count = min(int(conv.out_channels * self.rate_dist), len(keep) - 1)
+                keep_mask = torch.ones(len(keep), dtype=torch.bool)
+                for _ in range(remove_count):
+                    vals, _ = torch.min(D + torch.diag(torch.full((len(keep),), 10.0, device=D.device)), dim=1)
+                    idx = torch.argmin(vals)
+                    keep_mask[idx] = False
+                    D[idx, :] = 10
+                    D[:, idx] = 10
+                keep = keep[keep_mask]
+            num_keep = max(int(conv.out_channels * (1 - ratio)), 1)
+            if len(keep) > num_keep:
+                keep = keep[:num_keep]
+            mask = torch.zeros(conv.out_channels, dtype=torch.bool)
+            mask[keep] = True
+            self.masks.append(mask)
+
+    def apply_pruning(self) -> None:
+        for (parent, attr, bn), mask in zip(self.layers, self.masks):
+            conv = getattr(parent, attr)
+            keep_idx = mask.nonzero(as_tuple=False).squeeze(1)
+            if len(keep_idx) == conv.out_channels:
+                continue
+            new_conv = nn.Conv2d(
+                conv.in_channels,
+                len(keep_idx),
+                kernel_size=conv.kernel_size,
+                stride=conv.stride,
+                padding=conv.padding,
+                dilation=conv.dilation,
+                groups=conv.groups,
+                bias=conv.bias is not None,
+                padding_mode=conv.padding_mode,
+            )
+            new_conv.weight.data = conv.weight.data[keep_idx].clone()
+            if conv.bias is not None:
+                new_conv.bias.data = conv.bias.data[keep_idx].clone()
+            setattr(parent, attr, new_conv)
+            if bn is not None:
+                new_bn = nn.BatchNorm2d(len(keep_idx))
+                new_bn.weight.data = bn.weight.data[keep_idx].clone()
+                new_bn.bias.data = bn.bias.data[keep_idx].clone()
+                new_bn.running_mean = bn.running_mean[keep_idx].clone()
+                new_bn.running_var = bn.running_var[keep_idx].clone()
+                setattr(parent, "bn", new_bn)


### PR DESCRIPTION
## Summary
- add Isomorphic, HSIC-Lasso and Weighted Hybrid pruning algorithms
- lazily import pruning methods to avoid heavy deps during tests
- update dependency-graph methods to delay torch-pruning import
- expose new methods via main `METHODS_MAP`

## Testing
- `pytest tests/test_new_methods_import.py::test_new_methods_have_flag -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c318c49108324a792320335c38d33