### PR TITLE
Fix pruning method exports

### DIFF
--- a/prune_methods/__init__.py
+++ b/prune_methods/__init__.py
@@ -14,24 +14,21 @@ __all__ = [
     "WeightedHybridMethod",
 ]
 
+_MAPPING = {
+    "BasePruningMethod": ("prune_methods.base", "BasePruningMethod"),
+    "L1NormMethod": ("prune_methods.l1_norm", "L1NormMethod"),
+    "RandomMethod": ("prune_methods.random_pruning", "RandomMethod"),
+    "DepgraphMethod": ("prune_methods.depgraph_pruning", "DepgraphMethod"),
+    "TorchRandomMethod": ("prune_methods.torch_pruning_simple", "TorchRandomMethod"),
+    "IsomorphicMethod": ("prune_methods.isomorphic_pruning", "IsomorphicMethod"),
+    "HSICLassoMethod": ("prune_methods.hsic_lasso", "HSICLassoMethod"),
+    "DepgraphHSICMethod": ("prune_methods.depgraph_hsic", "DepgraphHSICMethod"),
+    "WeightedHybridMethod": ("prune_methods.weighted_hybrid", "WeightedHybridMethod"),
+}
+
 
 def __getattr__(name: str):
-    if name == "BasePruningMethod":
-        return import_module("prune_methods.base").BasePruningMethod
-    if name == "L1NormMethod":
-        return import_module("prune_methods.l1_norm").L1NormMethod
-    if name == "RandomMethod":
-        return import_module("prune_methods.random_pruning").RandomMethod
-    if name == "DepgraphMethod":
-        return import_module("prune_methods.depgraph_pruning").DepgraphMethod
-    if name == "TorchRandomMethod":
-        return import_module("prune_methods.torch_pruning_simple").TorchRandomMethod
-    if name == "IsomorphicMethod":
-        return import_module("prune_methods.isomorphic_pruning").IsomorphicMethod
-    if name == "HSICLassoMethod":
-        return import_module("prune_methods.hsic_lasso").HSICLassoMethod
-    if name == "DepgraphHSICMethod":
-        return import_module("prune_methods.depgraph_hsic").DepgraphHSICMethod
-    if name == "WeightedHybridMethod":
-        return import_module("prune_methods.weighted_hybrid").WeightedHybridMethod
+    if name in _MAPPING:
+        module, attr = _MAPPING[name]
+        return getattr(import_module(module), attr)
     raise AttributeError(name)

--- a/tests/test_new_methods_import.py
+++ b/tests/test_new_methods_import.py
@@ -11,12 +11,31 @@ sys.modules.setdefault("matplotlib", types.ModuleType("matplotlib"))
 sys.modules.setdefault("matplotlib.pyplot", types.ModuleType("matplotlib.pyplot"))
 sys.modules.setdefault("pandas", types.ModuleType("pandas"))
 sys.modules.setdefault("torch_pruning", types.ModuleType("torch_pruning"))
+sys.modules.setdefault("sklearn", types.ModuleType("sklearn"))
+linear_model_stub = types.ModuleType("sklearn.linear_model")
+class LassoLars:  # pragma: no cover - placeholder
+    pass
+linear_model_stub.LassoLars = LassoLars
+sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
 
 
 def test_new_methods_have_flag():
-    mod = __import__("prune_methods", fromlist=["DepgraphMethod", "TorchRandomMethod"])
+    mod = __import__(
+        "prune_methods",
+        fromlist=[
+            "L1NormMethod",
+            "RandomMethod",
+            "DepgraphMethod",
+            "TorchRandomMethod",
+            "DepgraphHSICMethod",
+        ],
+    )
+    assert hasattr(mod, "L1NormMethod")
+    assert hasattr(mod, "RandomMethod")
     DepGraph = mod.DepgraphMethod
     Simple = mod.TorchRandomMethod
+    HSIC = mod.DepgraphHSICMethod
     assert DepGraph.requires_reconfiguration is False
     assert Simple.requires_reconfiguration is False
+    assert HSIC.requires_reconfiguration is False
 


### PR DESCRIPTION
## Summary
- update lazy import mapping for pruning methods
- support importing DepgraphHSICMethod
- expand unit test coverage for new pruning method names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c4507e91483248184e53ca267a297