### PR TITLE
Fix pruning tests for renamed classes

### DIFF
--- a/tests/test_new_methods_import.py
+++ b/tests/test_new_methods_import.py
@@ -20,22 +20,25 @@ sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
 
 
 def test_new_methods_have_flag():
-    mod = __import__(
-        "prune_methods",
-        fromlist=[
-            "L1NormMethod",
-            "RandomMethod",
-            "DepgraphMethod",
-            "TorchRandomMethod",
-            "DepgraphHSICMethod",
-        ],
-    )
-    assert hasattr(mod, "L1NormMethod")
-    assert hasattr(mod, "RandomMethod")
+    names = [
+        "L1NormMethod",
+        "RandomMethod",
+        "DepgraphMethod",
+        "TorchRandomMethod",
+        "IsomorphicMethod",
+        "HSICLassoMethod",
+        "DepgraphHSICMethod",
+        "WeightedHybridMethod",
+    ]
+    mod = __import__("prune_methods", fromlist=names)
+    for name in names:
+        assert hasattr(mod, name)
     DepGraph = mod.DepgraphMethod
     Simple = mod.TorchRandomMethod
+    Iso = mod.IsomorphicMethod
     HSIC = mod.DepgraphHSICMethod
     assert DepGraph.requires_reconfiguration is False
     assert Simple.requires_reconfiguration is False
+    assert Iso.requires_reconfiguration is False
     assert HSIC.requires_reconfiguration is False
 


### PR DESCRIPTION
## Summary
- update test to check all pruning method names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c482852b083248fcd476d0fcff95a