### PR TITLE
Update docs for Depgraph-HSIC method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Ultralytics' format with `train`, `val` and `nc` fields.
 
 ```python
 from pipeline import PruningPipeline
+from prune_methods import DepgraphHSICMethod
 from pipeline.step import (
     LoadModelStep,
     CalcStatsStep,
@@ -42,7 +43,12 @@ steps = [
     CalcStatsStep("pruned"),
 ]
 
-pipeline = PruningPipeline("yolov8n-seg.pt", data="biotech_model_train.yaml", steps=steps)
+pipeline = PruningPipeline(
+    "yolov8n-seg.pt",
+    data="biotech_model_train.yaml",
+    pruning_method=DepgraphHSICMethod(None),  # model assigned by LoadModelStep
+    steps=steps,
+)
 context = pipeline.run_pipeline()
 print(context.metrics)
 ```
@@ -212,6 +218,12 @@ Available values for `--methods`:
 * `isomorphic`
 * `hsic_lasso`
 * `whc`
+
+The `depgraph_hsic` option maps to the ``DepgraphHSICMethod`` class. It collects
+feature activations and labels during forward passes, calculates HSIC scores to
+measure channel dependence on the targets and ranks them using ``LassoLars``.
+Pruning is then applied through ``torch-pruning``'s ``DependencyGraph`` to keep
+tensor shapes consistent.
 
 Add `--resume` to continue interrupted runs.
 Add `--heatmap-only` to generate heatmap visualizations without line plots.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -74,3 +74,18 @@ A typical set of steps might look as follows:
 
 This modular structure makes it easy to customise or extend the pruning process by defining new step classes or reordering existing ones.
 
+### Using ``DepgraphHSICMethod``
+
+Any pruning algorithm subclassing ``BasePruningMethod`` can be attached to the pipeline. ``DepgraphHSICMethod`` ranks channels via HSIC scores and prunes them through a dependency graph:
+
+```python
+from prune_methods import DepgraphHSICMethod
+
+pipeline = PruningPipeline(
+    "yolov8n-seg.pt",
+    data="dataset.yaml",
+    pruning_method=DepgraphHSICMethod(model),
+    steps=steps,
+)
+```
+


### PR DESCRIPTION
## Summary
- mention DepgraphHSICMethod in quick start guide and pipeline docs
- describe Depgraph‑HSIC algorithm

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684c49b520e88324973c0b0399657c95