### PR TITLE
Improve resume handling for completed runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,10 @@ measure channel dependence on the targets and ranks them using ``LassoLars``.
 Pruning is then applied through ``torch-pruning``'s ``DependencyGraph`` to keep
 tensor shapes consistent.
 
-Add `--resume` to continue interrupted runs.
+Add `--resume` to continue interrupted runs. If `weights/last.pt` is missing or
+`weights/best.pt` exists with `results.csv` showing that all configured epochs
+completed, training starts from scratch instead of resuming and a message is
+logged.
 Add `--heatmap-only` to generate heatmap visualizations without line plots.
 If baseline weights are already present in the working directory they will be
 reused by default, which skips the initial pretraining step. Disable this by

--- a/tests/test_resume_flag.py
+++ b/tests/test_resume_flag.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import main
+
+
+def test_resume_skipped_when_best_only(tmp_path, monkeypatch):
+    class DummyPipeline:
+        def __init__(self, *a, **k):
+            self.model = types.SimpleNamespace(model=object())
+            self.metrics_mgr = types.SimpleNamespace(
+                to_csv=lambda p: Path(p),
+                record_computation=lambda m: None,
+            )
+
+        def load_model(self):
+            pass
+
+        def calc_initial_stats(self):
+            pass
+
+        def pretrain(self, **kw):
+            DummyPipeline.kw = kw
+
+        def visualize_results(self):
+            pass
+
+        def save_pruning_results(self, path):
+            pass
+
+        def save_metrics_csv(self, path):
+            return Path(path)
+
+    monkeypatch.setattr(main, "PruningPipeline", DummyPipeline)
+
+    phase_dir = tmp_path / "baseline" / "weights"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "best.pt").touch()
+    (phase_dir.parent / "results.csv").write_text("epoch\n0\n")
+
+    cfg = main.TrainConfig(baseline_epochs=1, finetune_epochs=0, batch_size=1, ratios=[0])
+    main.execute_pipeline("m", "d", None, 0, cfg, tmp_path, resume=True)
+
+    assert DummyPipeline.kw["resume"] is False


### PR DESCRIPTION
## Summary
- reset resume flag when training already finished
- test that resume is ignored if only best.pt exists
- document resume logic in README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c5ff7fbdc8324887f7c0adce19096