### PR TITLE
Fix IsomorphicMethod for new torch-pruning

### DIFF
--- a/prune_methods/isomorphic_pruning.py
+++ b/prune_methods/isomorphic_pruning.py
@@ -36,7 +36,6 @@ class IsomorphicMethod(BasePruningMethod):
             self.model,
             example_inputs=self.example_inputs,
             importance=importance,
-            DG=self.DG,
             global_pruning=False,
             pruning_ratio=ratio,
             round_to=self.round_to,


### PR DESCRIPTION
## Summary
- keep compatibility with recent torch-pruning versions by removing the deprecated `DG` parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684c93e78738832486222f039ad25554