### PR TITLE
Ensure HSIC labels count match

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ is required.
 pass to compute pruning scores. When ``reuse_baseline=True`` the initial
 training can be skipped, but you should still run a training or evaluation step
 after ``AnalyzeModelStep`` so that activations are populated before pruning.
+Each forward pass that collects activations must also provide labels via
+``DepgraphHSICMethod.add_labels``; otherwise ``generate_pruning_mask`` will
+raise an error.
 
 Each run directory will contain a `pipeline.log` file capturing detailed
 training and pruning output for the selected ratio.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -89,3 +89,6 @@ pipeline = PruningPipeline(
 )
 ```
 
+Make sure to record labels for every forward pass using
+``DepgraphHSICMethod.add_labels`` so that activations and targets stay aligned.
+

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -86,6 +86,11 @@ class DepgraphHSICMethod(BasePruningMethod):
         return H @ K @ H
 
     def _hsic_scores(self, F: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        if F.shape[0] != y.shape[0]:
+            raise RuntimeError(
+                "Mismatched number of activations and labels. Labels must be "
+                "recorded for every forward pass using add_labels()."
+            )
         B, C, H, W = F.shape
         Ky = self._rbf_kernel(y.unsqueeze(1))
         scores = []

--- a/tests/test_hsic_label_mismatch.py
+++ b/tests/test_hsic_label_mismatch.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_generate_pruning_mask_requires_all_labels(tmp_path):
+    code = f"""
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.register_hooks()
+model(torch.randn(1, 3, 8, 8))
+method.add_labels(torch.tensor([1]))
+model(torch.randn(1, 3, 8, 8))
+method.generate_pruning_mask(0.5)
+"""
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "Labels must be" in proc.stderr + proc.stdout


### PR DESCRIPTION
## Summary
- check number of recorded labels inside `_hsic_scores`
- document label requirement in README files
- add regression test for label count mismatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684cb19077448324951640c5db14af86