### PR TITLE
Ensure CPU tensors in DepgraphHSIC hooks

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -47,12 +47,16 @@ class DepgraphHSICMethod(BasePruningMethod):
             target_shape = self.layer_shapes.get(idx)
             if target_shape is None:
                 self.layer_shapes[idx] = output.shape[2:]
-                processed = output.detach()
+                processed = output.detach().cpu()
             else:
                 if output.shape[2:] != target_shape:
-                    processed = torch.nn.functional.adaptive_avg_pool2d(output, target_shape).detach()
+                    processed = (
+                        torch.nn.functional.adaptive_avg_pool2d(output, target_shape)
+                        .detach()
+                        .cpu()
+                    )
                 else:
-                    processed = output.detach()
+                    processed = output.detach().cpu()
             self.activations.setdefault(idx, []).append(processed)
         return hook
 
@@ -74,7 +78,7 @@ class DepgraphHSICMethod(BasePruningMethod):
 
     def add_labels(self, y: torch.Tensor) -> None:
         """Store labels observed during a forward pass."""
-        self.labels.append(y.detach())
+        self.labels.append(y.detach().cpu())
 
     # ------------------------------------------------------------------
     # HSIC helpers


### PR DESCRIPTION
## Summary
- keep feature activations and labels on the CPU
- detach pooled activations before moving to CPU

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e1848a9488324a6740b940fd154a6