### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,20 +265,22 @@ The script automatically visualizes several metrics after all runs:
 
 ## Running tests
 
-The test suite relies on additional packages not required for the pruning
-pipeline itself. Install the following libraries before executing `pytest`:
+The test suite relies on additional packages not included in the pruning
+pipeline requirements. **Install `pandas`, `numpy`, and `torch` before running
+`pytest`.** You can install them directly or use the provided convenience file
+`requirements-test.txt`:
 
-* `torch`
-* `pandas`
-* `numpy`
+```bash
+pip install -r requirements-test.txt
+```
 
-You can install them using `pip`:
+Alternatively install them manually:
 
 ```bash
 pip install torch pandas numpy
 ```
 
-Once the dependencies are available run the tests with:
+Once the dependencies are available, run the tests with:
 
 ```bash
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pandas
+numpy
+torch


### PR DESCRIPTION
## Summary
- note torch, pandas and numpy must be installed before running `pytest`
- offer `requirements-test.txt` for convenience

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_b_684e19e83bc08324ab3a02b36cfb5a52