### PR TITLE
Add logging across pruning steps

### DIFF
--- a/pipeline/step/analyze.py
+++ b/pipeline/step/analyze.py
@@ -8,9 +8,12 @@ class AnalyzeModelStep(PipelineStep):
     """Analyze the model using the configured pruning method."""
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.pruning_method is None:
             raise NotImplementedError
         context.logger.info("Analyzing model structure")
         context.pruning_method.analyze_model()
+        context.logger.info("Finished %s", step)
 
 __all__ = ["AnalyzeModelStep"]

--- a/pipeline/step/apply_pruning.py
+++ b/pipeline/step/apply_pruning.py
@@ -8,9 +8,12 @@ class ApplyPruningStep(PipelineStep):
     """Apply the generated pruning mask to the model."""
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.pruning_method is None:
             raise NotImplementedError
         context.logger.info("Applying pruning mask")
         context.pruning_method.apply_pruning()
+        context.logger.info("Finished %s", step)
 
 __all__ = ["ApplyPruningStep"]

--- a/pipeline/step/calc_stats.py
+++ b/pipeline/step/calc_stats.py
@@ -15,6 +15,8 @@ class CalcStatsStep(PipelineStep):
         self.dest = dest
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.model is None:
             raise ValueError("Model is not loaded")
         context.logger.info("Calculating %s statistics", self.dest)
@@ -76,5 +78,6 @@ class CalcStatsStep(PipelineStep):
                     },
                 }
             )
+        context.logger.info("Finished %s", step)
 
 __all__ = ["CalcStatsStep"]

--- a/pipeline/step/compare.py
+++ b/pipeline/step/compare.py
@@ -8,10 +8,13 @@ class CompareModelsStep(PipelineStep):
     """Visualize and save comparison plots using the pruning method."""
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.pruning_method is None:
             return
         context.logger.info("Visualizing pruning results")
         context.pruning_method.visualize_comparison()
         context.pruning_method.visualize_pruned_filters()
+        context.logger.info("Finished %s", step)
 
 __all__ = ["CompareModelsStep"]

--- a/pipeline/step/generate_masks.py
+++ b/pipeline/step/generate_masks.py
@@ -11,9 +11,12 @@ class GenerateMasksStep(PipelineStep):
         self.ratio = ratio
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.pruning_method is None:
             raise NotImplementedError
         context.logger.info("Generating pruning mask at ratio %.2f", self.ratio)
         context.pruning_method.generate_pruning_mask(self.ratio)
+        context.logger.info("Finished %s", step)
 
 __all__ = ["GenerateMasksStep"]

--- a/pipeline/step/load_model.py
+++ b/pipeline/step/load_model.py
@@ -10,7 +10,10 @@ class LoadModelStep(PipelineStep):
     """Load a YOLO model from ``context.model_path``."""
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         context.logger.info("Loading model from %s", context.model_path)
         context.model = YOLO(context.model_path)
+        context.logger.info("Finished %s", step)
 
 __all__ = ["LoadModelStep"]

--- a/pipeline/step/monitor_computation.py
+++ b/pipeline/step/monitor_computation.py
@@ -59,8 +59,11 @@ class MonitorComputationStep(PipelineStep):
         return metrics
 
     def run(self, context: PipelineContext) -> None:  # pragma: no cover - not used in tests
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         metrics = self.stop(context.metrics_mgr)
         context.metrics.setdefault("computation", {})[self.phase] = metrics
+        context.logger.info("Finished %s", step)
 
 
 __all__ = ["MonitorComputationStep"]

--- a/pipeline/step/reconfigure.py
+++ b/pipeline/step/reconfigure.py
@@ -12,9 +12,12 @@ class ReconfigureModelStep(PipelineStep):
         self.reconfigurator = AdaptiveLayerReconfiguration()
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.model is None:
             raise ValueError("Model is not loaded")
         context.logger.info("Reconfiguring model")
         self.reconfigurator.reconfigure_model(context.model)
+        context.logger.info("Finished %s", step)
 
 __all__ = ["ReconfigureModelStep"]

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -18,6 +18,8 @@ class TrainStep(PipelineStep):
         self.train_kwargs = train_kwargs
 
     def run(self, context: PipelineContext) -> None:
+        step = self.__class__.__name__
+        context.logger.info("Starting %s", step)
         if context.model is None:
             raise ValueError("Model is not loaded")
         context.logger.info("Training model (%s)", self.phase)
@@ -44,5 +46,6 @@ class TrainStep(PipelineStep):
         metrics = context.model.train(data=context.data, **self.train_kwargs)
         context.metrics_mgr.record_training(metrics or {})
         context.metrics[self.phase] = metrics or {}
+        context.logger.info("Finished %s", step)
 
 __all__ = ["TrainStep"]

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -173,6 +173,7 @@ class DepgraphHSICMethod(BasePruningMethod):
     # BasePruningMethod interface
     # ------------------------------------------------------------------
     def analyze_model(self) -> None:  # pragma: no cover - heavy dependency
+        self.logger.info("Analyzing model")
         import torch_pruning as tp
 
         self.DG = tp.DependencyGraph()
@@ -182,6 +183,7 @@ class DepgraphHSICMethod(BasePruningMethod):
         self._build_channel_groups()
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         if not self.activations or not self.labels:
             raise RuntimeError("No activations/labels collected. Run a forward pass first.")
         features = {}
@@ -240,6 +242,7 @@ class DepgraphHSICMethod(BasePruningMethod):
             removed += len(chans)
 
     def apply_pruning(self) -> None:  # pragma: no cover - heavy dependency
+        self.logger.info("Applying pruning")
         if self.DG is None:
             raise RuntimeError("analyze_model must be called first")
         import torch_pruning as tp

--- a/prune_methods/depgraph_pruning.py
+++ b/prune_methods/depgraph_pruning.py
@@ -19,11 +19,13 @@ class DepgraphMethod(BasePruningMethod):
 
     def analyze_model(self) -> None:
         """Build and store the dependency graph for ``self.model``."""
+        self.logger.info("Analyzing model")
         import torch_pruning as tp  # local import
         self.DG = tp.DependencyGraph()
         self.DG.build_dependency(self.model, self.example_inputs)
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         import torch_pruning as tp
         importance = tp.importance.MagnitudeImportance(p=2)
         pruner_cls = getattr(tp, "MagnitudePruner", tp.pruner.algorithms.BasePruner)
@@ -36,6 +38,7 @@ class DepgraphMethod(BasePruningMethod):
         )
 
     def apply_pruning(self) -> None:
+        self.logger.info("Applying pruning")
         if self.pruner is None:
             raise RuntimeError("generate_pruning_mask must be called first")
         self.pruner.step()

--- a/prune_methods/hsic_lasso.py
+++ b/prune_methods/hsic_lasso.py
@@ -22,6 +22,7 @@ class HSICLassoMethod(BasePruningMethod):
 
     def analyze_model(self) -> None:
         """Collect convolution layers from the first 10 backbone modules."""
+        self.logger.info("Analyzing model")
         backbone = list(self.model.model[:10])
         for module in backbone:
             for name, m in module.named_modules():
@@ -60,6 +61,7 @@ class HSICLassoMethod(BasePruningMethod):
         return torch.tensor(scores)
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         self.ratio = ratio
         self.masks = []
         for idx, (parent, attr, _) in enumerate(self.layers):
@@ -76,6 +78,7 @@ class HSICLassoMethod(BasePruningMethod):
             self.masks.append(mask)
 
     def apply_pruning(self) -> None:
+        self.logger.info("Applying pruning")
         for (parent, attr, bn), mask in zip(self.layers, self.masks):
             conv = getattr(parent, attr)
             keep_idx = mask.nonzero(as_tuple=False).squeeze(1)

--- a/prune_methods/isomorphic_pruning.py
+++ b/prune_methods/isomorphic_pruning.py
@@ -25,11 +25,13 @@ class IsomorphicMethod(BasePruningMethod):
         self.pruner = None
 
     def analyze_model(self) -> None:  # pragma: no cover - heavy dependency
+        self.logger.info("Analyzing model")
         import torch_pruning as tp
         self.DG = tp.DependencyGraph()
         self.DG.build_dependency(self.model, self.example_inputs)
 
     def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover - heavy dependency
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         import torch_pruning as tp
         importance = tp.importance.MagnitudeImportance(p=1)
         self.pruner = tp.MagnitudePruner(
@@ -42,6 +44,7 @@ class IsomorphicMethod(BasePruningMethod):
         )
 
     def apply_pruning(self) -> None:  # pragma: no cover - heavy dependency
+        self.logger.info("Applying pruning")
         if self.pruner is None:
             raise RuntimeError("generate_pruning_mask must be called first")
         self.pruner.step()

--- a/prune_methods/l1_norm.py
+++ b/prune_methods/l1_norm.py
@@ -20,6 +20,7 @@ class L1NormMethod(BasePruningMethod):
 
     def analyze_model(self) -> None:
         """Collect convolution layers from the first 10 backbone modules."""
+        self.logger.info("Analyzing model")
         backbone = list(self.model.model[:10])
         for module in backbone:
             for name, m in module.named_modules():
@@ -31,6 +32,7 @@ class L1NormMethod(BasePruningMethod):
                     self.layers.append((parent, name.split(".")[-1], bn))
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         self.ratio = ratio
         self.masks = []
         for parent, attr, _ in self.layers:
@@ -51,6 +53,7 @@ class L1NormMethod(BasePruningMethod):
             self.masks.append(mask)
 
     def apply_pruning(self) -> None:
+        self.logger.info("Applying pruning")
         for (parent, attr, bn), mask in zip(self.layers, self.masks):
             conv = getattr(parent, attr)
             keep_idx = mask.nonzero(as_tuple=False).squeeze(1)

--- a/prune_methods/random_pruning.py
+++ b/prune_methods/random_pruning.py
@@ -20,6 +20,7 @@ class RandomMethod(BasePruningMethod):
 
     def analyze_model(self) -> None:
         """Collect convolution layers from the first 10 backbone modules."""
+        self.logger.info("Analyzing model")
         backbone = list(self.model.model[:10])
         for module in backbone:
             for name, m in module.named_modules():
@@ -31,6 +32,7 @@ class RandomMethod(BasePruningMethod):
                     self.layers.append((parent, name.split(".")[-1], bn))
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         self.ratio = ratio
         self.masks = []
         for parent, attr, _ in self.layers:
@@ -50,6 +52,7 @@ class RandomMethod(BasePruningMethod):
             self.masks.append(mask)
 
     def apply_pruning(self) -> None:
+        self.logger.info("Applying pruning")
         for (parent, attr, bn), mask in zip(self.layers, self.masks):
             conv = getattr(parent, attr)
             keep_idx = mask.nonzero(as_tuple=False).squeeze(1)

--- a/prune_methods/torch_pruning_simple.py
+++ b/prune_methods/torch_pruning_simple.py
@@ -20,11 +20,13 @@ class TorchRandomMethod(BasePruningMethod):
 
     def analyze_model(self) -> None:
         """Build and store the dependency graph for ``self.model``."""
+        self.logger.info("Analyzing model")
         import torch_pruning as tp
         self.DG = tp.DependencyGraph()
         self.DG.build_dependency(self.model, self.example_inputs)
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         import torch_pruning as tp
         importance = tp.importance.RandomImportance()
         pruner_cls = getattr(tp, "RandomPruner", getattr(tp, "MagnitudePruner", tp.pruner.algorithms.BasePruner))
@@ -37,6 +39,7 @@ class TorchRandomMethod(BasePruningMethod):
         )
 
     def apply_pruning(self) -> None:
+        self.logger.info("Applying pruning")
         if self.pruner is None:
             raise RuntimeError("generate_pruning_mask must be called first")
         self.pruner.step()

--- a/prune_methods/weighted_hybrid.py
+++ b/prune_methods/weighted_hybrid.py
@@ -22,6 +22,7 @@ class WeightedHybridMethod(BasePruningMethod):
 
     def analyze_model(self) -> None:
         """Collect convolution layers from the first 10 backbone modules."""
+        self.logger.info("Analyzing model")
         backbone = list(self.model.model[:10])
         for module in backbone:
             for name, m in module.named_modules():
@@ -38,6 +39,7 @@ class WeightedHybridMethod(BasePruningMethod):
         return 1 - sim
 
     def generate_pruning_mask(self, ratio: float) -> None:
+        self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         self.ratio = ratio
         self.masks = []
         for parent, attr, _ in self.layers:
@@ -65,6 +67,7 @@ class WeightedHybridMethod(BasePruningMethod):
             self.masks.append(mask)
 
     def apply_pruning(self) -> None:
+        self.logger.info("Applying pruning")
         for (parent, attr, bn), mask in zip(self.layers, self.masks):
             conv = getattr(parent, attr)
             keep_idx = mask.nonzero(as_tuple=False).squeeze(1)


### PR DESCRIPTION
## Summary
- log analyze/generate/apply steps in all pruning methods
- add start/finish logs to each pipeline step

## Testing
- `pip install -q -r requirements-test.txt` *(fails: ModuleNotFoundError: matplotlib)*
- `pytest -q` *(fails: ModuleNotFoundError: matplotlib, CalledProcessError for torch)*

------
https://chatgpt.com/codex/tasks/task_b_684e1cfc12c48324a9be9810c664bdcb