### PR TITLE
Add stats comparison logging helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ context = pipeline.run_pipeline()
 print(pipeline.record_metrics())
 ```
 
+Example log output:
+
+```
+INFO - Calculating pruned statistics
+metric         initial  pruned  reduction  %
+parameters     27000    18000   9000       33.3%
+flops          100.0    70.0    30.0       30.0%
+filters        100      80      20         20.0%
+model_size_mb  4.5      3.0     1.5       33.3%
+```
+
 The YAML file describing the dataset should have at least the following keys:
 
 ```yaml

--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -9,7 +9,7 @@ from .heatmap_visualizer import (
     DEFAULT_METRICS,
 )
 from .metrics_loader import load_metrics_dataframe
-from .model_stats import count_filters, model_size_mb
+from .model_stats import count_filters, model_size_mb, log_stats_comparison
 
 __all__ = [
     "Logger",
@@ -23,4 +23,5 @@ __all__ = [
     "load_metrics_dataframe",
     "count_filters",
     "model_size_mb",
+    "log_stats_comparison",
 ]

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -11,6 +11,7 @@ from helper import (
     MetricManager,
     count_filters,
     model_size_mb,
+    log_stats_comparison,
 )
 from .model_reconfig import AdaptiveLayerReconfiguration
 from .context import PipelineContext
@@ -187,6 +188,7 @@ class PruningPipeline(BasePruningPipeline):
                 },
             }
         )
+        log_stats_comparison(self.initial_stats, self.pruned_stats, self.logger)
         return self.pruned_stats
 
     def finetune(self, *, device: str | int | list = 0, **train_kwargs: Any) -> Dict[str, Any]:

--- a/pipeline/step/calc_stats.py
+++ b/pipeline/step/calc_stats.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ultralytics.utils.torch_utils import get_flops, get_num_params
 
-from helper import count_filters, model_size_mb
+from helper import count_filters, model_size_mb, log_stats_comparison
 
 from ..context import PipelineContext
 from . import PipelineStep
@@ -78,6 +78,7 @@ class CalcStatsStep(PipelineStep):
                     },
                 }
             )
+            log_stats_comparison(context.initial_stats, context.pruned_stats, context.logger)
         context.logger.info("Finished %s", step)
 
 __all__ = ["CalcStatsStep"]


### PR DESCRIPTION
## Summary
- format stats comparison table in helper.log_stats_comparison
- display table when calculating pruned stats
- document sample log output

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e605d1bd48324ab12a44aebe3de04