### PR TITLE
Add debug log for label recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ for images, labels in dataloader:
 
 Each run directory will contain a `pipeline.log` file capturing detailed
 training and pruning output for the selected ratio.
+Enabling `--debug` will log a message whenever batch labels are recorded,
+including their shape.
 
 Use `--device` to select the training device (defaults to `cuda:0`).
 The script automatically visualizes several metrics after all runs:

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -34,6 +34,9 @@ class TrainStep(PipelineStep):
             def record_labels(trainer) -> None:  # pragma: no cover - heavy dependency
                 batch = getattr(trainer, "batch", None)
                 if isinstance(batch, dict) and "cls" in batch:
+                    context.logger.debug(
+                        "Adding labels for batch with shape %s", tuple(batch["cls"].shape)
+                    )
                     context.pruning_method.add_labels(batch["cls"])
 
             try:


### PR DESCRIPTION
## Summary
- log label batches during training
- mention debug logging in README

## Testing
- `pip install -r requirements-test.txt`
- `pip install matplotlib`
- `pip install seaborn torch_pruning`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e689ed290832489db01baa7df4084