### PR TITLE
Add debug log for missing activations

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -207,6 +207,11 @@ class DepgraphHSICMethod(BasePruningMethod):
     def generate_pruning_mask(self, ratio: float) -> None:
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         if not self.activations or not self.labels:
+            self.logger.debug(
+                "generate_pruning_mask called with %d labels and activations for %d layers",
+                len(self.labels),
+                len(self.activations),
+            )
             raise RuntimeError("No activations/labels collected. Run a forward pass first.")
         label_batches = len(self.labels)
         self.logger.info("Recorded %d label batches", label_batches)


### PR DESCRIPTION
## Summary
- add extra debug logging when DepgraphHSICMethod is called without prior forward pass

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684e6b47f4488324a471c594587257b7