### PR TITLE
Add customizable label aggregation to TrainStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,23 @@ image_labels = cls[:, 0]
 pruning_method.add_labels(image_labels)
 ```
 
+The same aggregation can be automated when using
+``TrainStep`` by providing a ``label_fn``:
+
+```python
+def aggregate_labels(batch):
+    cls = batch["cls"].view(batch["img"].shape[0], -1)
+    return cls[:, 0]
+
+steps = [
+    TrainStep("pretrain", label_fn=aggregate_labels, epochs=1),
+    ...
+]
+```
+
+``DepgraphHSICMethod`` will call ``label_fn`` for each batch before adding
+labels internally.
+
 Automatic recording for training pipelines is implemented in
 ``pipeline/step/train.py`` where :class:`~pipeline.step.train.TrainStep` adds a
 callback on ``on_train_batch_end`` to store ``batch["cls"]`` after each forward


### PR DESCRIPTION
## Summary
- allow TrainStep to accept `label_fn` for custom label aggregation
- use `label_fn` when automatically recording labels for DepgraphHSICMethod
- document custom `label_fn` example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e7740bf8c8324a39a67ef70b76d88