### PR TITLE
Fix README workflow for DepgraphHSICMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ be installed automatically.
 
 After installing the dependencies you can run the pruning pipeline as shown
 below. The example expects the dataset to be defined in a YAML file following
-Ultralytics' format with `train`, `val` and `nc` fields.
-Some methods, such as `DepgraphHSICMethod`, rely on activations and labels
-collected during model analysis, so `AnalyzeModelStep` must run before any
-training.
+Ultralytics' format with `train`, `val` and `nc` fields. When using
+`DepgraphHSICMethod` you must record labels for every forward pass and run a
+training or validation step before analyzing the model so activations and
+labels are available.
 
 ```python
 from pipeline import PruningPipeline
@@ -39,8 +39,8 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    AnalyzeModelStep(),
     TrainStep("pretrain", epochs=1, plots=True),
+    AnalyzeModelStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     CalcStatsStep("pruned"),
@@ -252,10 +252,10 @@ is required.
 ``DepgraphHSICMethod`` needs activations and labels obtained from a forward
 pass to compute pruning scores. When ``reuse_baseline=True`` the initial
 training can be skipped, but you should still run a training or evaluation step
-after ``AnalyzeModelStep`` so that activations are populated before pruning.
-When using :class:`~pipeline.step.train.TrainStep` labels are automatically
-recorded after each batch. For custom loops this must be done manually or
-``generate_pruning_mask`` will raise an error:
+before ``AnalyzeModelStep`` so that activations and labels are populated for
+scoring. When using :class:`~pipeline.step.train.TrainStep` labels are
+automatically recorded after each batch. For custom loops this must be done
+manually or ``generate_pruning_mask`` will raise an error:
 
 ```python
 for images, labels in dataloader:


### PR DESCRIPTION
## Summary
- document that a training or validation step should run before analysis when using `DepgraphHSICMethod`
- swap `TrainStep("pretrain")` and `AnalyzeModelStep` in quick start snippet
- clarify that activations and labels must be recorded every forward pass

## Testing
- `pip install -r requirements-test.txt`
- `pip install matplotlib`
- `pip install git+https://github.com/VainF/Torch-Pruning.git`
- `pytest -q` *(fails: Module 'matplotlib' has no attribute 'artist')*

------
https://chatgpt.com/codex/tasks/task_b_684e9302ba008324834f55808e2cf255