### PR TITLE
Fix README pruning sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # depgraph_hsic_pruning
 
-This repository contains utilities based on the Ultralytics YOLO stack. A pruning
-pipeline is provided for orchestrating model preparation, pruning and
-fine-tuning.
+This repository contains utilities based on the Ultralytics YOLO stack.
+A pruning pipeline is provided for orchestrating model preparation, pruning and fine-tuning.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- fix early README sentence to keep `pruning` intact

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib', 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_684e93fe0ec08324b493d02d018dfd9c