### PR TITLE
Implement reset_records docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,9 @@ steps = [
 ``DepgraphHSICMethod`` will call ``label_fn`` for each batch before adding
 labels internally.
 
-Calling ``analyze_model()`` clears any previously stored activations and
-labels so that subsequent training phases start with a clean slate.
+Calling ``analyze_model()`` clears any stored activations, recorded layer
+shapes, activation counters and labels so that subsequent training phases
+start with a clean slate.
 
 Automatic recording for training pipelines is implemented in
 ``pipeline/step/train.py`` where :class:`~pipeline.step.train.TrainStep` adds a

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -96,7 +96,12 @@ class DepgraphHSICMethod(BasePruningMethod):
         self.logger.debug("Total labels recorded: %d", len(self.labels))
 
     def reset_records(self) -> None:
-        """Clear stored activations and labels."""
+        """Clear all collected activation data and labels.
+
+        This removes cached activations, per-layer shapes, the activation
+        counters and any stored labels so a new round of recording can begin
+        without leftovers from previous passes.
+        """
         self.activations.clear()
         self.layer_shapes.clear()
         self.num_activations.clear()


### PR DESCRIPTION
## Summary
- clarify behavior of DepgraphHSICMethod.reset_records
- document resetting in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e963d5bc08324aadaff0db8b240d1