### PR TITLE
Update pipeline docs

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -58,10 +58,10 @@ A typical set of steps might look as follows:
 
 1. `LoadModelStep()`
 2. `CalcStatsStep("initial")`
-3. `MonitorComputationStep("pretrain")` *(start before training)*
-4. `TrainStep("pretrain", epochs=1, plots=True)`
-5. `MonitorComputationStep("pretrain")` *(stop after training)*
-6. `AnalyzeModelStep()`
+3. `AnalyzeModelStep()`
+4. `MonitorComputationStep("pretrain")` *(start before training)*
+5. `TrainStep("pretrain", epochs=1, plots=True)`
+6. `MonitorComputationStep("pretrain")` *(stop after training)*
 7. `GenerateMasksStep(ratio=0.2)`
 8. `ApplyPruningStep()`
 9. `ReconfigureModelStep()`
@@ -69,6 +69,10 @@ A typical set of steps might look as follows:
 11. `MonitorComputationStep("finetune")` *(start before training)*
 12. `TrainStep("finetune", epochs=3, plots=True)`
 13. `MonitorComputationStep("finetune")` *(stop after training)*
+
+`AnalyzeModelStep` registers forward hooks and clears previously recorded
+activations or statistics, so a training pass must follow it to populate fresh
+data for pruning.
 
 `PruningPipeline` will execute them sequentially, passing the same context object to each. Statistics and metrics are accumulated inside `context` and can be retrieved at the end via `pipeline.record_metrics()` or directly from `context.metrics`.
 


### PR DESCRIPTION
## Summary
- reorder typical workflow so hooks are registered before training
- clarify that AnalyzeModelStep clears previous records and needs another training pass

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684ea39e7f1483248f911d4df24b89a9