### PR TITLE
Assign model to pruning method

### DIFF
--- a/pipeline/step/load_model.py
+++ b/pipeline/step/load_model.py
@@ -14,6 +14,19 @@ class LoadModelStep(PipelineStep):
         context.logger.info("Starting %s", step)
         context.logger.info("Loading model from %s", context.model_path)
         context.model = YOLO(context.model_path)
+        # Automatically attach the YOLO model to the pruning method if it was
+        # instantiated without one.  This mirrors the quick-start example in the
+        # README where ``DepgraphHSICMethod(None)`` is provided and the model is
+        # assigned after loading.
+        pm = getattr(context, "pruning_method", None)
+        if pm is not None and getattr(pm, "model", None) is None:
+            try:
+                pm.model = context.model.model
+                context.logger.debug(
+                    "Assigned loaded model to pruning method %s", pm.__class__.__name__
+                )
+            except Exception:  # pragma: no cover - best effort
+                pass
         context.logger.info("Finished %s", step)
 
 __all__ = ["LoadModelStep"]

--- a/tests/test_hsic_pipeline_auto_labels.py
+++ b/tests/test_hsic_pipeline_auto_labels.py
@@ -91,10 +91,8 @@ steps = [
     GenerateMasksStep(ratio=0.5),
 ]
 
-for i, step in enumerate(steps):
+for step in steps:
     step.run(ctx)
-    if i == 0:
-        ctx.pruning_method.model = ctx.model.model
 print('ok')
 """.format(tmp=tmp_path)
     proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- auto-attach the loaded YOLO model to the pruning method inside `LoadModelStep`
- simplify HSIC pipeline test to rely on the automatic attachment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684ea00d97988324a83e149e2ac288fb