### PR TITLE
Use isinstance check for HSIC callback

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -96,7 +96,12 @@ class PruningPipeline(BasePruningPipeline):
 
     def _register_label_callback(self, label_fn) -> None:
         """Attach a callback to record labels for ``DepgraphHSICMethod``."""
-        if getattr(self.pruning_method, "__class__", None).__name__ != "DepgraphHSICMethod":
+        try:
+            from prune_methods.depgraph_hsic import DepgraphHSICMethod  # local import to avoid heavy dependency at module import
+        except Exception:  # pragma: no cover - dependency missing
+            DepgraphHSICMethod = None
+
+        if DepgraphHSICMethod is None or not isinstance(self.pruning_method, DepgraphHSICMethod):
             return
 
         def record_labels(trainer) -> None:  # pragma: no cover - heavy dependency

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -79,6 +79,7 @@ def test_device_argument_passed(monkeypatch):
     class DummyPipeline:
         def __init__(self, *a, **k):
             self.model = types.SimpleNamespace(model=object())
+            self.pruning_method = None
 
         def load_model(self):
             pass

--- a/tests/test_train_step_warning.py
+++ b/tests/test_train_step_warning.py
@@ -26,9 +26,14 @@ def test_train_step_logs_warning_for_object_labels(monkeypatch, caplog):
 
     ctx = PipelineContext(model_path="m", data="d")
 
+    depgraph_mod = types.ModuleType("prune_methods.depgraph_hsic")
+
     class DepgraphHSICMethod:
         def add_labels(self, labels):
             self.last = labels
+
+    depgraph_mod.DepgraphHSICMethod = DepgraphHSICMethod
+    monkeypatch.setitem(sys.modules, "prune_methods.depgraph_hsic", depgraph_mod)
 
     ctx.pruning_method = DepgraphHSICMethod()
 


### PR DESCRIPTION
## Summary
- avoid name-based class check when adding HSIC label callback
- guard the import of `DepgraphHSICMethod` to avoid heavy dependencies
- adjust tests for the new check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684eb650ccec8324977d8fff187b4ba5