### PR TITLE
Fix HSIC method detection

### DIFF
--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+
 from ..context import PipelineContext
 from . import PipelineStep
 
@@ -31,7 +32,12 @@ class TrainStep(PipelineStep):
         # after the model has produced outputs, ensuring activations and labels
         # stay aligned.  Avoid registering duplicate callbacks across multiple
         # training phases.
-        if getattr(context, "pruning_method", None).__class__.__name__ == "DepgraphHSICMethod":
+        try:
+            from prune_methods.depgraph_hsic import DepgraphHSICMethod  # local import to avoid heavy dependency at module import
+        except Exception:  # pragma: no cover - dependency missing
+            DepgraphHSICMethod = None
+
+        if DepgraphHSICMethod is not None and isinstance(getattr(context, "pruning_method", None), DepgraphHSICMethod):
             def record_labels(trainer) -> None:  # pragma: no cover - heavy dependency
                 batch = getattr(trainer, "batch", None)
                 if isinstance(batch, dict) and "cls" in batch:

--- a/prune_methods/__init__.py
+++ b/prune_methods/__init__.py
@@ -30,5 +30,8 @@ _MAPPING = {
 def __getattr__(name: str):
     if name in _MAPPING:
         module, attr = _MAPPING[name]
-        return getattr(import_module(module), attr)
+        obj = getattr(import_module(module), attr)
+        if name.endswith("Method") and not hasattr(obj, "requires_reconfiguration"):
+            obj.requires_reconfiguration = False
+        return obj
     raise AttributeError(name)


### PR DESCRIPTION
## Summary
- improve HSIC method detection by using isinstance
- ensure lazy imported pruning methods define `requires_reconfiguration`

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ed602a6f48324b0189f42ae3768e0