### PR TITLE
Improve HSIC logging and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Use `main.py` to run all pruning methods across several ratios in one go:
 python main.py --model yolov8n-seg.pt \
     --baseline-epochs 1 --finetune-epochs 3 --batch-size 16 --ratios 0.2 0.4 0.6 0.8
 ```
+Add `--debug` to enable additional batch-level logging during training.
 The dataset defaults to `biotech_model_train.yaml` if `--data` is not supplied.
 Available values for `--methods`:
 

--- a/main.py
+++ b/main.py
@@ -192,8 +192,10 @@ def execute_pipeline(
                 else:
                     img = val_path if val_path.exists() else None
                 if img is not None:
+                    logger.info("short forward pass image: %s", img)
                     label_file = Path(str(img)).with_suffix(".txt").as_posix()
                     label_file = label_file.replace("/images/", "/labels/")
+                    logger.info("short forward pass label file: %s", label_file)
                     y = torch.tensor([])
                     lf = Path(label_file)
                     if lf.exists():
@@ -201,6 +203,7 @@ def execute_pipeline(
                             labels = [float(line.split()[0]) for line in lf_f if line.strip()]
                         if labels:
                             y = torch.tensor([labels[0]])
+                            logger.info("label file %s has %d entries", label_file, len(labels))
                         else:
                             logger.warning("label file %s is empty", label_file)
                     else:

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -82,6 +82,7 @@ class DepgraphHSICMethod(BasePruningMethod):
                 self.layers.append(m)
                 self.handles.append(m.register_forward_hook(self._activation_hook(idx)))
                 idx += 1
+        self.logger.info("Registered hooks for %d Conv2d layers", len(self.layers))
 
     def remove_hooks(self) -> None:
         for h in self.handles:
@@ -92,8 +93,8 @@ class DepgraphHSICMethod(BasePruningMethod):
         """Store labels observed during a forward pass."""
         processed = y.detach().cpu()
         self.labels.append(processed)
-        self.logger.debug("Recorded label with shape %s", tuple(processed.shape))
-        self.logger.debug("Total labels recorded: %d", len(self.labels))
+        self.logger.info("Recorded label tensor shape %s", tuple(processed.shape))
+        self.logger.info("Cumulative labels stored: %d", len(self.labels))
 
     def reset_records(self) -> None:
         """Clear all collected activation data and labels.


### PR DESCRIPTION
## Summary
- log chosen sample paths in the short forward pass
- log label statistics when registering example labels
- report number of Conv2d layers hooked
- mention `--debug` usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68515f2a39b883248e63e75806039928