### PR TITLE
Add logging to reset_records

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -102,6 +102,13 @@ class DepgraphHSICMethod(BasePruningMethod):
         counters and any stored labels so a new round of recording can begin
         without leftovers from previous passes.
         """
+        act_count = sum(len(v) for v in self.activations.values())
+        label_count = len(self.labels)
+        self.logger.info(
+            "Resetting records: clearing %d activations and %d labels",
+            act_count,
+            label_count,
+        )
         self.activations.clear()
         self.layer_shapes.clear()
         self.num_activations.clear()


### PR DESCRIPTION
## Summary
- count stored activations and labels before clearing
- log counts at INFO level when resetting records

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68515f33d598832497da351d5afb27ab