### PR TITLE
Use new torch-pruning API for HSIC pruning

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -305,6 +305,10 @@ class DepgraphHSICMethod(BasePruningMethod):
 
         for layer, idxs in self.pruning_plan.items():
             unique = sorted(set(idxs))
-            self.DG.prune_layer(layer, unique, dim=0)
-        tp.utils.remove_pruning_reparametrization(self.model)
+            group = self.DG.get_pruning_group(
+                layer,
+                tp.prune_conv_out_channels,
+                unique,
+            )
+            group.prune()
         self.remove_hooks()

--- a/tests/test_hsic_apply_pruning.py
+++ b/tests/test_hsic_apply_pruning.py
@@ -1,0 +1,42 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_hsic_apply_pruning_reduces_params(tmp_path):
+    code = f"""
+import json
+import torch
+import sys
+import importlib.metadata
+import torch_pruning as tp
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+
+ver = tuple(map(int, importlib.metadata.version("torch_pruning").split(".")[:2]))
+assert ver >= (1, 5)
+
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.example_inputs = torch.randn(1, 3, 8, 8)
+method.analyze_model()
+for _ in range(2):
+    model(torch.randn(1, 3, 8, 8))
+    method.add_labels(torch.tensor([1.0]))
+method.generate_pruning_mask(0.5)
+before = sum(p.numel() for p in model.parameters())
+method.apply_pruning()
+after = sum(p.numel() for p in model.parameters())
+json.dump([before, after], sys.stdout)
+"""
+    out = subprocess.check_output([sys.executable, "-c", code])
+    before, after = json.loads(out.decode())
+    assert after < before
+


### PR DESCRIPTION
## Summary
- update `DepgraphHSICMethod.apply_pruning` to use pruning groups
- remove obsolete `remove_pruning_reparametrization` call
- add regression test ensuring pruning works with torch-pruning>=1.5

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685171ebdde483248febd20d249e59ac