### PR TITLE
Update README for external ultralytics dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ pipeline = PruningPipeline(
 context = pipeline.run_pipeline()
 print(context.metrics)
 ```
-
 ## Package structure
 
 ```
@@ -63,8 +62,10 @@ pipeline/
     pruning_pipeline.py  # default implementation
     context.py          # shared pipeline state
     step/               # modular pipeline steps
-ultralytics/     # fork of the Ultralytics package
 ```
+
+The `ultralytics` package is installed as an external dependency and is not
+part of this repository.
 
 Importing from `pipeline` exposes both `BasePruningPipeline` and
 `PruningPipeline`.
@@ -167,7 +168,7 @@ val: path/to/val/images
 nc: 80  # number of classes
 ```
 
-See the `ultralytics/cfg/datasets` directory for examples.
+See the official Ultralytics documentation for dataset YAML examples.
 
 ## Helper utilities
 


### PR DESCRIPTION
## Summary
- clarify that ultralytics is an external dependency
- update package-structure snippet accordingly
- point dataset example note to Ultralytics documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68518330c99c83249902733b8c8133d9