### PR TITLE
Ensure pruning method uses updated model post-training

### DIFF
--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -127,6 +127,8 @@ class MetricManager:
             return out
 
         flat = _flatten(self.as_dict())
+        for field in TRAINING_METRIC_FIELDS:
+            flat.setdefault(f"training.{field}", "")
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", newline="") as f:

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -166,6 +166,9 @@ class PruningPipeline(BasePruningPipeline):
             metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         finally:
             self._unregister_label_callback()
+        if self.pruning_method is not None:
+            self.pruning_method.model = self.model.model
+            self.logger.debug("updated pruning method model reference")
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["pretrain"] = metrics
@@ -269,6 +272,9 @@ class PruningPipeline(BasePruningPipeline):
             metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         finally:
             self._unregister_label_callback()
+        if self.pruning_method is not None:
+            self.pruning_method.model = self.model.model
+            self.logger.debug("updated pruning method model reference")
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["finetune"] = metrics

--- a/tests/test_pruning_method_model_update.py
+++ b/tests/test_pruning_method_model_update.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# ensure real torch is available
+import torch  # noqa: F401
+
+up = types.ModuleType('ultralytics')
+utils = types.ModuleType('ultralytics.utils')
+torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+torch_utils.get_flops = lambda *a, **k: 0
+torch_utils.get_num_params = lambda *a, **k: 0
+utils.torch_utils = torch_utils
+
+class DummyYOLO:
+    def __init__(self):
+        self.model = types.SimpleNamespace(id=0)
+        self.callbacks = {}
+    def add_callback(self, event, cb):
+        self.callbacks.setdefault(event, []).append(cb)
+    def train(self, *a, **k):
+        self.model = types.SimpleNamespace(id=self.model.id + 1)
+        return {}
+
+up.YOLO = lambda *a, **k: DummyYOLO()
+sys.modules['ultralytics'] = up
+sys.modules['ultralytics.utils'] = utils
+sys.modules['ultralytics.utils.torch_utils'] = torch_utils
+
+base_mod = types.ModuleType('prune_methods.base')
+class DummyMethod:
+    def __init__(self, model=None, **kw):
+        self.model = model
+base_mod.BasePruningMethod = DummyMethod
+sys.modules['prune_methods.base'] = base_mod
+
+import importlib
+pp = importlib.import_module('pipeline.pruning_pipeline')
+pp.YOLO = up.YOLO
+
+
+def test_pruning_method_model_updated_after_training():
+    method = DummyMethod(None)
+    pipeline = pp.PruningPipeline('m', 'd', pruning_method=method)
+    pipeline.model = DummyYOLO()
+    pipeline.pretrain()
+    assert pipeline.pruning_method.model is pipeline.model.model
+    pipeline.finetune()
+    assert pipeline.pruning_method.model is pipeline.model.model


### PR DESCRIPTION
## Summary
- sync the pruning method's model reference after YOLO training phases
- keep training metric headers consistent in CSV output
- test that pruning method model reference updates after pretrain and finetune

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68518320d510832489fbd4642d89bb28