### PR TITLE
Handle depgraph rebuild on pruning and regression test

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -305,10 +305,19 @@ class DepgraphHSICMethod(BasePruningMethod):
 
         for layer, idxs in self.pruning_plan.items():
             unique = sorted(set(idxs))
-            group = self.DG.get_pruning_group(
-                layer,
-                tp.prune_conv_out_channels,
-                unique,
-            )
+            try:
+                group = self.DG.get_pruning_group(
+                    layer,
+                    tp.prune_conv_out_channels,
+                    unique,
+                )
+            except ValueError:
+                self.logger.info("Rebuilding dependency graph before pruning")
+                self.DG.build_dependency(self.model, self.example_inputs)
+                group = self.DG.get_pruning_group(
+                    layer,
+                    tp.prune_conv_out_channels,
+                    unique,
+                )
             group.prune()
         self.remove_hooks()

--- a/tests/test_hsic_dependency_rebuild.py
+++ b/tests/test_hsic_dependency_rebuild.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_pruning_after_layer_replacement(tmp_path):
+    code = f"""
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+import torch_pruning as tp
+
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.example_inputs = torch.randn(1, 3, 8, 8)
+method.analyze_model()
+model[0] = torch.nn.Conv2d(3, 4, 3)
+method.pruning_plan = {{model[0]: [0]}}
+method.apply_pruning()
+print('ok')
+"""
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert 'ok' in proc.stdout


### PR DESCRIPTION
## Summary
- rebuild dependency graph on ValueError in DepgraphHSICMethod.apply_pruning
- add regression test for applying pruning after replacing a convolution layer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68519801a6508324a2d408410974a816