### PR TITLE
Fix pruning pipeline analysis handling

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -171,9 +171,24 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
-            if model_changed and hasattr(self.pruning_method, "analyze_model"):
-                self.logger.debug("model instance changed during training; rebuilding dependency graph")
+            if hasattr(self.pruning_method, "analyze_model"):
+                if not model_changed:
+                    saved = (
+                        getattr(self.pruning_method, "activations", None),
+                        getattr(self.pruning_method, "layer_shapes", None),
+                        getattr(self.pruning_method, "num_activations", None),
+                        getattr(self.pruning_method, "labels", None),
+                    )
+                self.logger.debug(
+                    "model instance%s changed during training; rebuilding dependency graph",
+                    "" if model_changed else " not",
+                )
                 self.pruning_method.analyze_model()
+                if not model_changed and saved[0] is not None:
+                    self.pruning_method.activations = saved[0]
+                    self.pruning_method.layer_shapes = saved[1]
+                    self.pruning_method.num_activations = saved[2]
+                    self.pruning_method.labels = saved[3]
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["pretrain"] = metrics
@@ -282,9 +297,24 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
-            if model_changed and hasattr(self.pruning_method, "analyze_model"):
-                self.logger.debug("model instance changed during training; rebuilding dependency graph")
+            if hasattr(self.pruning_method, "analyze_model"):
+                if not model_changed:
+                    saved = (
+                        getattr(self.pruning_method, "activations", None),
+                        getattr(self.pruning_method, "layer_shapes", None),
+                        getattr(self.pruning_method, "num_activations", None),
+                        getattr(self.pruning_method, "labels", None),
+                    )
+                self.logger.debug(
+                    "model instance%s changed during training; rebuilding dependency graph",
+                    "" if model_changed else " not",
+                )
                 self.pruning_method.analyze_model()
+                if not model_changed and saved[0] is not None:
+                    self.pruning_method.activations = saved[0]
+                    self.pruning_method.layer_shapes = saved[1]
+                    self.pruning_method.num_activations = saved[2]
+                    self.pruning_method.labels = saved[3]
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["finetune"] = metrics

--- a/tests/test_pipeline_inplace_layer_change.py
+++ b/tests/test_pipeline_inplace_layer_change.py
@@ -1,0 +1,95 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_pipeline_prunes_after_inplace_change(tmp_path):
+    code = """
+import json
+import sys
+import types
+import torch
+
+sys.modules['matplotlib'] = types.ModuleType('matplotlib')
+sys.modules['matplotlib.pyplot'] = types.ModuleType('matplotlib.pyplot')
+
+class DummyDG:
+    def build_dependency(self, model, example_inputs):
+        pass
+    def get_all_groups(self, root_module_types=None):
+        return []
+    def get_pruner_of_module(self, layer):
+        return types.SimpleNamespace(get_out_channels=lambda l: getattr(l, 'out_channels', 0))
+    def get_pruning_group(self, conv, fn, idxs):
+        class Group(list):
+            def __init__(self):
+                super().__init__([(types.SimpleNamespace(target=types.SimpleNamespace(module=conv)), idxs)])
+            def prune(self):
+                mask = torch.ones(conv.out_channels, dtype=torch.bool)
+                for i in idxs:
+                    mask[i] = False
+                conv.out_channels = int(mask.sum())
+                conv.weight = torch.nn.Parameter(conv.weight[mask])
+                if conv.bias is not None:
+                    conv.bias = torch.nn.Parameter(conv.bias[mask])
+        return Group()
+
+tp = types.ModuleType('torch_pruning')
+tp.DependencyGraph = DummyDG
+tp.prune_conv_out_channels = lambda *a, **k: None
+tp.utils = types.SimpleNamespace(remove_pruning_reparametrization=lambda m: None)
+sys.modules['torch_pruning'] = tp
+
+class DummyYOLO:
+    def __init__(self):
+        self.model = torch.nn.Sequential(
+            torch.nn.Conv2d(3,4,3),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(4,8,3),
+            torch.nn.ReLU(),
+        )
+        self.callbacks = {{}}
+    def add_callback(self, event, cb):
+        self.callbacks.setdefault(event, []).append(cb)
+    def train(self, *a, **k):
+        self.model[0] = torch.nn.Conv2d(3,4,3)
+        return {{}}
+
+up = types.ModuleType('ultralytics')
+utils = types.ModuleType('ultralytics.utils')
+torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+torch_utils.get_flops = lambda *a, **k: 0
+torch_utils.get_num_params = lambda *a, **k: 0
+utils.torch_utils = torch_utils
+up.utils = utils
+up.YOLO = lambda *a, **k: DummyYOLO()
+sys.modules['ultralytics'] = up
+sys.modules['ultralytics.utils'] = utils
+sys.modules['ultralytics.utils.torch_utils'] = torch_utils
+
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+from pipeline.pruning_pipeline import PruningPipeline
+
+method = DepgraphHSICMethod(None, workdir='{tmp}')
+pipeline = PruningPipeline('m', 'd', pruning_method=method)
+pipeline.model = DummyYOLO()
+method.model = pipeline.model.model
+method.example_inputs = torch.randn(1,3,8,8)
+pipeline.analyze_structure()
+method.remove_hooks()
+pipeline.pretrain()
+for _ in range(2):
+    pipeline.model.model(torch.randn(1,3,8,8))
+    method.add_labels(torch.tensor([1.0]))
+pipeline.generate_pruning_mask(0.5)
+before = sum(p.numel() for p in pipeline.model.model.parameters())
+pipeline.apply_pruning()
+after = sum(p.numel() for p in pipeline.model.model.parameters())
+json.dump([before, after], sys.stdout)
+""".format(tmp=tmp_path)
+    out = subprocess.check_output([sys.executable, "-c", code])
+    before, after = json.loads(out.decode())
+    assert after < before

--- a/tests/test_pruning_method_preserve_records.py
+++ b/tests/test_pruning_method_preserve_records.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# ensure real torch is available
+import torch  # noqa: F401
+
+up = types.ModuleType('ultralytics')
+utils = types.ModuleType('ultralytics.utils')
+torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+torch_utils.get_flops = lambda *a, **k: 0
+torch_utils.get_num_params = lambda *a, **k: 0
+utils.torch_utils = torch_utils
+
+class DummyYOLO:
+    def __init__(self):
+        self.model = types.SimpleNamespace(id=0)
+        self.callbacks = {}
+    def add_callback(self, event, cb):
+        self.callbacks.setdefault(event, []).append(cb)
+    def train(self, *a, **k):
+        # mutate model but keep same instance
+        self.model.id += 1
+        return {}
+
+up.YOLO = lambda *a, **k: DummyYOLO()
+sys.modules['ultralytics'] = up
+sys.modules['ultralytics.utils'] = utils
+sys.modules['ultralytics.utils.torch_utils'] = torch_utils
+
+base_mod = types.ModuleType('prune_methods.base')
+class DummyMethod:
+    def __init__(self, model=None, **kw):
+        self.model = model
+        self.calls = 0
+        self.activations = {0: [0]}
+        self.layer_shapes = {0: (1, 1)}
+        self.num_activations = {0: 1}
+        self.labels = [0]
+    def analyze_model(self):
+        self.calls += 1
+        # emulate analyze_model clearing records
+        self.activations = {}
+        self.layer_shapes = {}
+        self.num_activations = {}
+        self.labels = []
+base_mod.BasePruningMethod = DummyMethod
+sys.modules['prune_methods.base'] = base_mod
+
+import importlib
+pp = importlib.import_module('pipeline.pruning_pipeline')
+pp.YOLO = up.YOLO
+
+
+def test_records_preserved_when_model_unchanged():
+    method = DummyMethod(None)
+    pipeline = pp.PruningPipeline('m', 'd', pruning_method=method)
+    pipeline.model = DummyYOLO()
+    pipeline.pretrain()
+    assert method.calls == 1
+    assert method.activations == {0: [0]}
+    pipeline.finetune()
+    assert method.calls == 2
+    assert method.activations == {0: [0]}


### PR DESCRIPTION
## Summary
- ensure PruningPipeline rebuilds dependency graph after each training phase
- keep collected activations when the model instance stays the same
- add regression tests for activation preservation and in-place layer changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68519ea17b7883248e51e4928b53e1e4