### PR TITLE
Limit HSIC hook scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ steps = [
 pipeline = PruningPipeline(
     "yolov8n-seg.pt",
     data="biotech_model_train.yaml",
-    pruning_method=DepgraphHSICMethod(None),  # model assigned by LoadModelStep
+    pruning_method=DepgraphHSICMethod(None, num_modules=10),  # model assigned by LoadModelStep
     steps=steps,
 )
 context = pipeline.run_pipeline()
@@ -239,6 +239,11 @@ feature activations and labels during forward passes, calculates HSIC scores to
 measure channel dependence on the targets and ranks them using ``LassoLars``.
 Pruning is then applied through ``torch-pruning``'s ``DependencyGraph`` to keep
 tensor shapes consistent.
+
+``DepgraphHSICMethod`` accepts a ``num_modules`` argument controlling how many
+modules from ``model.model`` are inspected when hooks are registered. The
+default value of ``10`` covers the YOLOv8 backbone while avoiding the neck and
+head layers if they are not required.
 
 Add `--resume` to continue interrupted runs. If `weights/last.pt` is missing or
 `weights/best.pt` exists with `results.csv` showing that all configured epochs

--- a/tests/test_hsic_hook_limit.py
+++ b/tests/test_hsic_hook_limit.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_hooks_only_first_modules(tmp_path):
+    code = f"""
+import json
+import sys
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+
+class Dummy(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = torch.nn.ModuleList([torch.nn.Conv2d(3, 3, 1) for _ in range(12)])
+
+model = Dummy()
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.register_hooks()
+json.dump({{"count": len(method.layers), "names": method.layer_names}}, sys.stdout)
+"""
+    out = subprocess.check_output([sys.executable, "-c", code])
+    data = json.loads(out.decode())
+    assert data['count'] == 10
+    assert data['names'][0] == "model.0"
+    assert data['names'][-1] == "model.9"


### PR DESCRIPTION
## Summary
- add `num_modules` to DepgraphHSICMethod
- remove previous hooks before registering new ones and only scan the requested modules
- document the new parameter in README and class docstring
- add a regression test for layer registration limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851a7caf3948324a8283e2459686858