### PR TITLE
Clarify test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,16 @@ The script automatically visualizes several metrics after all runs:
 
 ## Running tests
 
-The test suite relies on additional packages not included in the pruning pipeline requirements. These include `pandas`, `numpy`, `torch`, `scikit-learn`, `matplotlib`, `seaborn`, and `torch-pruning`. Install them using the provided `requirements-test.txt` file:
+Running the tests requires a few extra packages that are not included in the
+main `requirements.txt`. Install them with:
 
 ```bash
 pip install -r requirements-test.txt
 ```
 
-Alternatively install them manually:
+These packages include `pandas`, `numpy`, `torch`, `scikit-learn`,
+`matplotlib`, `seaborn`, and `torch-pruning`. Alternatively install them
+manually:
 
 ```bash
 pip install torch pandas numpy scikit-learn matplotlib seaborn torch-pruning

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+import importlib
+import pytest
+
+REQUIRED_PACKAGES = [
+    "pandas",
+    "numpy",
+    "torch",
+    "sklearn",
+    "matplotlib",
+    "seaborn",
+    "torch_pruning",
+]
+
+missing = [pkg for pkg in REQUIRED_PACKAGES if importlib.util.find_spec(pkg) is None]
+
+if missing:
+    pytest.skip(
+        "Missing test dependencies: {}. Install them with 'pip install -r requirements-test.txt'".format(
+            ", ".join(missing)
+        ),
+        allow_module_level=True,
+    )


### PR DESCRIPTION
## Summary
- document that tests need `requirements-test.txt`
- add a `conftest.py` that skips tests if required dependencies are missing

## Testing
- `pytest -q` *(fails: Missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68525b5e24908324bd316fc0bea27931