### PR TITLE
Fix README workflow steps

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -58,10 +58,10 @@ A typical set of steps might look as follows:
 
 1. `LoadModelStep()`
 2. `CalcStatsStep("initial")`
-3. `AnalyzeModelStep()`
-4. `MonitorComputationStep("pretrain")` *(start before training)*
-5. `TrainStep("pretrain", epochs=1, plots=True)`
-6. `MonitorComputationStep("pretrain")` *(stop after training)*
+3. `MonitorComputationStep("pretrain")` *(start before training)*
+4. `TrainStep("pretrain", epochs=1, plots=True)`
+5. `MonitorComputationStep("pretrain")` *(stop after training)*
+6. `AnalyzeModelStep()`
 7. `GenerateMasksStep(ratio=0.2)`
 8. `ApplyPruningStep()`
 9. `ReconfigureModelStep()`
@@ -71,8 +71,8 @@ A typical set of steps might look as follows:
 13. `MonitorComputationStep("finetune")` *(stop after training)*
 
 `AnalyzeModelStep` registers forward hooks and clears previously recorded
-activations or statistics, so a training pass must follow it to populate fresh
-data for pruning.
+activations or statistics, so a training or validation pass must follow it to
+populate activations and labels for pruning.
 
 `PruningPipeline` will execute them sequentially, passing the same context object to each. Statistics and metrics are accumulated inside `context` and can be retrieved at the end via `pipeline.record_metrics()` or directly from `context.metrics`.
 


### PR DESCRIPTION
## Summary
- reorder steps in the pipeline README so that pretraining comes before AnalyzeModelStep
- clarify that training or validation must follow analysis to collect activations and labels

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68527f9ecad88324a8109ab29c3cc4aa