### PR TITLE
Refactor pipeline order for HSIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    TrainStep("pretrain", epochs=1, plots=True),
     AnalyzeModelStep(),
-    TrainStep("collect", epochs=1, plots=False),  # or a validation step to record activations
+    TrainStep("pretrain", epochs=1, plots=True),  # collects activations
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     CalcStatsStep("pruned"),
@@ -130,8 +129,8 @@ from pipeline.step import (
 steps = [
     LoadModelStep(),
     CalcStatsStep("initial"),
-    TrainStep("pretrain", epochs=1, plots=True),
     AnalyzeModelStep(),
+    TrainStep("pretrain", epochs=1, plots=True),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     ReconfigureModelStep(),

--- a/main.py
+++ b/main.py
@@ -179,6 +179,7 @@ def execute_pipeline(
     pipeline.calc_initial_stats()
     if method_cls is not None:
         pipeline.set_pruning_method(method_cls(pipeline.model.model, workdir=workdir))
+        pipeline.analyze_structure()
 
     if config.baseline_epochs > 0:
         monitor = MonitorComputationStep("pretrain")
@@ -204,7 +205,7 @@ def execute_pipeline(
             mgr = pipeline.metrics_mgr = MetricManager()
         monitor.stop(mgr)
 
-    if method_cls is not None:
+    if method_cls is not None and config.baseline_epochs == 0:
         pipeline.analyze_structure()
         if (
             isinstance(getattr(pipeline, "pruning_method", None), DepgraphHSICMethod)


### PR DESCRIPTION
## Summary
- analyze model before the pretraining phase so HSIC hooks capture activations
- update README snippets to show the new step order

## Testing
- `pytest -q` *(fails: Missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6852ae4d9bec83248b8f399e91fd7de5