### PR TITLE
Fix depgraph dependency tuple usage

### DIFF
--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -109,3 +109,10 @@ class BasePruningMethod(abc.ABC):
             "pruned": self.pruned_stats,
         }
         torch.save(data, path)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _inputs_tuple(self) -> tuple[torch.Tensor]:
+        """Return ``example_inputs`` wrapped in a tuple."""
+        return (self.example_inputs,)

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -266,7 +266,7 @@ class DepgraphHSICMethod(BasePruningMethod):
 
         self.logger.debug("Building dependency graph")
         self.DG = tp.DependencyGraph()
-        self.DG.build_dependency(self.model, self.example_inputs)
+        self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
         self.logger.debug("Dependency graph built")
         self.register_hooks()
         self._build_adjacency()
@@ -374,7 +374,7 @@ class DepgraphHSICMethod(BasePruningMethod):
                 self.logger.info("Rebuilding dependency graph before pruning")
                 # recreate the DependencyGraph in case the model changed
                 self.DG = tp.DependencyGraph()
-                self.DG.build_dependency(self.model, self.example_inputs)
+                self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
                 named_modules = dict(self.model.named_modules())
                 self.logger.debug(
                     "dependency graph modules: %s", list(named_modules.keys())

--- a/prune_methods/depgraph_pruning.py
+++ b/prune_methods/depgraph_pruning.py
@@ -22,7 +22,7 @@ class DepgraphMethod(BasePruningMethod):
         self.logger.info("Analyzing model")
         import torch_pruning as tp  # local import
         self.DG = tp.DependencyGraph()
-        self.DG.build_dependency(self.model, self.example_inputs)
+        self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
 
     def generate_pruning_mask(self, ratio: float) -> None:
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
@@ -31,7 +31,7 @@ class DepgraphMethod(BasePruningMethod):
         pruner_cls = getattr(tp, "MagnitudePruner", tp.pruner.algorithms.BasePruner)
         self.pruner = pruner_cls(
             self.model,
-            example_inputs=self.example_inputs,
+            example_inputs=self._inputs_tuple(),
             importance=importance,
             pruning_ratio=ratio,
             iterative_steps=1,

--- a/prune_methods/isomorphic_pruning.py
+++ b/prune_methods/isomorphic_pruning.py
@@ -28,7 +28,7 @@ class IsomorphicMethod(BasePruningMethod):
         self.logger.info("Analyzing model")
         import torch_pruning as tp
         self.DG = tp.DependencyGraph()
-        self.DG.build_dependency(self.model, self.example_inputs)
+        self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
 
     def generate_pruning_mask(self, ratio: float) -> None:  # pragma: no cover - heavy dependency
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
@@ -36,7 +36,7 @@ class IsomorphicMethod(BasePruningMethod):
         importance = tp.importance.MagnitudeImportance(p=1)
         self.pruner = tp.MagnitudePruner(
             self.model,
-            example_inputs=self.example_inputs,
+            example_inputs=self._inputs_tuple(),
             importance=importance,
             global_pruning=False,
             pruning_ratio=ratio,

--- a/prune_methods/torch_pruning_simple.py
+++ b/prune_methods/torch_pruning_simple.py
@@ -23,7 +23,7 @@ class TorchRandomMethod(BasePruningMethod):
         self.logger.info("Analyzing model")
         import torch_pruning as tp
         self.DG = tp.DependencyGraph()
-        self.DG.build_dependency(self.model, self.example_inputs)
+        self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
 
     def generate_pruning_mask(self, ratio: float) -> None:
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
@@ -32,7 +32,7 @@ class TorchRandomMethod(BasePruningMethod):
         pruner_cls = getattr(tp, "RandomPruner", getattr(tp, "MagnitudePruner", tp.pruner.algorithms.BasePruner))
         self.pruner = pruner_cls(
             self.model,
-            example_inputs=self.example_inputs,
+            example_inputs=self._inputs_tuple(),
             importance=importance,
             pruning_ratio=ratio,
             iterative_steps=1,


### PR DESCRIPTION
## Summary
- add `_inputs_tuple` helper in BasePruningMethod
- use tuple form of `example_inputs` when building DependencyGraph
- pass tuple to pruner constructors

## Testing
- `pytest -q` *(fails: test_pipeline_runs_without_baseline, test_remove_pruning_reparam_called)*

------
https://chatgpt.com/codex/tasks/task_b_6852b71d7e788324850c75eaf729aa53