### PR TITLE
Fix tuple usage for dependency rebuild

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -374,7 +374,7 @@ class DepgraphHSICMethod(BasePruningMethod):
                 self.logger.info("Rebuilding dependency graph before pruning")
                 # recreate the DependencyGraph in case the model changed
                 self.DG = tp.DependencyGraph()
-                self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
+                self.DG.build_dependency(self.model, (self.example_inputs,))
                 named_modules = dict(self.model.named_modules())
                 self.logger.debug(
                     "dependency graph modules: %s", list(named_modules.keys())


### PR DESCRIPTION
## Summary
- fix tuple wrapping for dependency rebuild path

## Testing
- `pytest -q` *(fails: 2 failed, 42 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6852bf20b0cc83249a29cea4c06003af