### PR TITLE
Ensure tuple-wrapped example inputs

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -374,7 +374,7 @@ class DepgraphHSICMethod(BasePruningMethod):
                 self.logger.info("Rebuilding dependency graph before pruning")
                 # recreate the DependencyGraph in case the model changed
                 self.DG = tp.DependencyGraph()
-                self.DG.build_dependency(self.model, (self.example_inputs,))
+                self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
                 named_modules = dict(self.model.named_modules())
                 self.logger.debug(
                     "dependency graph modules: %s", list(named_modules.keys())


### PR DESCRIPTION
## Summary
- rebuild dependency graph with tuple-wrapped example inputs

## Testing
- `pytest -q` *(fails: test_baseline_skip_pipeline, test_remove_pruning_reparam_called)*

------
https://chatgpt.com/codex/tasks/task_b_6852cd3350f08324b036a10691e6ed06