### PR TITLE
Ensure apply_pruning rebuilds dependency graph

### DIFF
--- a/main.py
+++ b/main.py
@@ -206,7 +206,6 @@ def execute_pipeline(
         monitor.stop(mgr)
 
     if method_cls is not None and config.baseline_epochs == 0:
-        pipeline.analyze_structure()
         if (
             isinstance(getattr(pipeline, "pruning_method", None), DepgraphHSICMethod)
             and config.reuse_baseline

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -354,6 +354,11 @@ class DepgraphHSICMethod(BasePruningMethod):
             raise RuntimeError("analyze_model must be called first")
         import torch_pruning as tp
 
+        # Always rebuild the dependency graph in case the model changed
+        self.logger.debug("Rebuilding dependency graph before pruning")
+        self.DG = tp.DependencyGraph()
+        self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
+
         named_modules = dict(self.model.named_modules())
 
         for name, idxs in self.pruning_plan.items():

--- a/tests/test_remove_reparam.py
+++ b/tests/test_remove_reparam.py
@@ -18,7 +18,7 @@ class DummyGroup(list):
         self.conv.reparam = True
 
 class DummyDG:
-    def build_dependency(self, model, ex):
+    def build_dependency(self, model, example_inputs=None):
         pass
     def get_pruning_group(self, conv, fn, idxs):
         return DummyGroup(conv, idxs)
@@ -47,7 +47,7 @@ model = torch.nn.Sequential(
 method = DepgraphHSICMethod(model, workdir='{tmp_path}')
 method.example_inputs = torch.randn(1,3,8,8)
 method.DG = DummyDG()
-method.pruning_plan = {'0': [0]}
+method.pruning_plan = {{'0': [0]}}
 method.apply_pruning()
 print(len(calls))
 print(hasattr(model[0], 'reparam'))


### PR DESCRIPTION
## Summary
- refresh dependency graph at the start of `apply_pruning`
- avoid redundant analyse call when skipping baseline
- fix remove reparam test helper for new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6852de57679883249d6408b358a1d06a