### PR TITLE
Ensure example inputs use model device

### DIFF
--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -114,5 +114,11 @@ class BasePruningMethod(abc.ABC):
     # Internal helpers
     # ------------------------------------------------------------------
     def _inputs_tuple(self) -> tuple[torch.Tensor]:
-        """Return ``example_inputs`` wrapped in a tuple."""
+        """Return ``example_inputs`` wrapped in a tuple on ``self.model``'s device."""
+        if torch.is_tensor(self.example_inputs):
+            try:
+                device = next(self.model.parameters()).device
+            except StopIteration:  # pragma: no cover - model without parameters
+                device = torch.device("cpu")
+            return (self.example_inputs.to(device),)
         return (self.example_inputs,)

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -265,6 +265,12 @@ class DepgraphHSICMethod(BasePruningMethod):
         import torch_pruning as tp
 
         self.logger.debug("Building dependency graph")
+        try:
+            device = next(self.model.parameters()).device
+        except StopIteration:  # pragma: no cover - model without parameters
+            device = torch.device("cpu")
+        if torch.is_tensor(self.example_inputs):
+            self.example_inputs = self.example_inputs.to(device)
         self.DG = tp.DependencyGraph()
         self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
         self.logger.debug("Dependency graph built")


### PR DESCRIPTION
## Summary
- move example inputs to the model's device before dependency graph creation
- keep `_inputs_tuple()` tensors on the model's device

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852e6c273088324a9f78ea3bfa4fe6c