### PR TITLE
Support list inputs for _inputs_tuple

### DIFF
--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -121,4 +121,14 @@ class BasePruningMethod(abc.ABC):
             except StopIteration:  # pragma: no cover - model without parameters
                 device = torch.device("cpu")
             return (self.example_inputs.to(device),)
+
+        if isinstance(self.example_inputs, (list, tuple)) and all(
+            torch.is_tensor(t) for t in self.example_inputs
+        ):
+            try:
+                device = next(self.model.parameters()).device
+            except StopIteration:  # pragma: no cover - model without parameters
+                device = torch.device("cpu")
+            return tuple(t.to(device) for t in self.example_inputs)
+
         return (self.example_inputs,)

--- a/tests/test_inputs_tuple.py
+++ b/tests/test_inputs_tuple.py
@@ -1,0 +1,43 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _run(example, tmp_path):
+    code = f"""
+import json
+import sys
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+).to(device)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.example_inputs = {example}
+method.analyze_model()
+info = {{'layers': len(method.layers), 'devices': [str(t.device) for t in method._inputs_tuple()], 'expected': str(device)}}
+json.dump(info, sys.stdout)
+"""
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    return json.loads(proc.stdout)
+
+
+def test_dependency_graph_builds_with_list_inputs(tmp_path):
+    data = _run('[torch.randn(1,3,8,8)]', tmp_path)
+    assert data['layers'] > 0
+    assert all(d == data['expected'] for d in data['devices'])
+
+
+def test_dependency_graph_builds_with_tuple_inputs(tmp_path):
+    data = _run('(torch.randn(1,3,8,8),)', tmp_path)
+    assert data['layers'] > 0
+    assert all(d == data['expected'] for d in data['devices'])


### PR DESCRIPTION
## Summary
- handle list or tuple example inputs in `BasePruningMethod._inputs_tuple`
- add tests ensuring dependency graph creation accepts list and tuple inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685303e45e308324ba3d1a529a4f3ab1