### PR TITLE
Fix pretrain reanalysis and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ forward pass on the first validation image so that a label is recorded for HSIC
 scoring. The dependency graph is already available from the initial analysis,
 so calling ``pipeline.analyze_structure()`` again is unnecessary and will clear
 any collected activations and labels.
+When baseline training does run ``PruningPipeline.pretrain()`` reanalyses the
+model after training. If the YOLO instance is unchanged activations and labels
+are restored so pruning can proceed without another forward pass.
 
 ``DepgraphHSICMethod`` needs activations and labels obtained from a forward
 pass to compute pruning scores. When ``reuse_baseline=True`` the initial
@@ -318,6 +321,8 @@ start with a clean slate.
 If training replaces the underlying model object the pipeline detects the
 change and automatically calls ``analyze_model()`` again so that the dependency
 graph and hooks are rebuilt for the new instance.
+``PruningPipeline.pretrain()`` performs the same reanalysis even when the model
+object is unchanged and restores any recorded activations and labels afterward.
 
 ### Reanalyzing after structural changes
 

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -172,6 +172,7 @@ class PruningPipeline(BasePruningPipeline):
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
             if hasattr(self.pruning_method, "analyze_model"):
+                saved: tuple | None = None
                 if not model_changed:
                     saved = (
                         getattr(self.pruning_method, "activations", None),
@@ -184,7 +185,7 @@ class PruningPipeline(BasePruningPipeline):
                     "" if model_changed else " not",
                 )
                 self.pruning_method.analyze_model()
-                if not model_changed and saved[0] is not None:
+                if not model_changed and saved is not None and saved[0] is not None:
                     self.pruning_method.activations = saved[0]
                     self.pruning_method.layer_shapes = saved[1]
                     self.pruning_method.num_activations = saved[2]


### PR DESCRIPTION
## Summary
- always rebuild dependency graph after `pretrain` regardless of model swap
- document how `pretrain` handles reanalysis in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68530917b2988324aecf23fb9425165e