### PR TITLE
Add explicit post-training analysis step

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ steps = [
     ShortForwardPassStep(),  # used when baseline training is skipped
     TrainStep("pretrain", epochs=1, plots=True),  # collects activations
     AnalyzeAfterTrainingStep(),
+    ShortForwardPassStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     CalcStatsStep("pruned"),
@@ -126,6 +127,7 @@ from pipeline.step import (
     CalcStatsStep,
     TrainStep,
     AnalyzeModelStep,
+    ShortForwardPassStep,
     AnalyzeAfterTrainingStep,
     GenerateMasksStep,
     ApplyPruningStep,
@@ -138,6 +140,7 @@ steps = [
     AnalyzeModelStep(),
     TrainStep("pretrain", epochs=1, plots=True),
     AnalyzeAfterTrainingStep(),
+    ShortForwardPassStep(),
     GenerateMasksStep(ratio=0.2),
     ApplyPruningStep(),
     ReconfigureModelStep(),

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -64,13 +64,14 @@ A typical set of steps might look as follows:
 6. `TrainStep("pretrain", epochs=1, plots=True)`
 7. `MonitorComputationStep("pretrain")` *(stop after training)*
 8. `AnalyzeAfterTrainingStep()`
-9. `GenerateMasksStep(ratio=0.2)`
-10. `ApplyPruningStep()`
-11. `ReconfigureModelStep()`
-12. `CalcStatsStep("pruned")`
-13. `MonitorComputationStep("finetune")` *(start before training)*
-14. `TrainStep("finetune", epochs=3, plots=True)`
-15. `MonitorComputationStep("finetune")` *(stop after training)*
+9. `ShortForwardPassStep()`
+10. `GenerateMasksStep(ratio=0.2)`
+11. `ApplyPruningStep()`
+12. `ReconfigureModelStep()`
+13. `CalcStatsStep("pruned")`
+14. `MonitorComputationStep("finetune")` *(start before training)*
+15. `TrainStep("finetune", epochs=3, plots=True)`
+16. `MonitorComputationStep("finetune")` *(stop after training)*
 
 `AnalyzeModelStep` registers forward hooks and clears previously recorded
 activations or statistics, so a training or validation pass must follow it to

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -171,24 +171,6 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
-            if hasattr(self.pruning_method, "analyze_model"):
-                if not model_changed:
-                    saved = (
-                        getattr(self.pruning_method, "activations", None),
-                        getattr(self.pruning_method, "layer_shapes", None),
-                        getattr(self.pruning_method, "num_activations", None),
-                        getattr(self.pruning_method, "labels", None),
-                    )
-                self.logger.debug(
-                    "model instance%s changed during training; rebuilding dependency graph",
-                    "" if model_changed else " not",
-                )
-                self.pruning_method.analyze_model()
-                if not model_changed and saved[0] is not None:
-                    self.pruning_method.activations = saved[0]
-                    self.pruning_method.layer_shapes = saved[1]
-                    self.pruning_method.num_activations = saved[2]
-                    self.pruning_method.labels = saved[3]
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["pretrain"] = metrics
@@ -297,24 +279,6 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
-            if hasattr(self.pruning_method, "analyze_model"):
-                if not model_changed:
-                    saved = (
-                        getattr(self.pruning_method, "activations", None),
-                        getattr(self.pruning_method, "layer_shapes", None),
-                        getattr(self.pruning_method, "num_activations", None),
-                        getattr(self.pruning_method, "labels", None),
-                    )
-                self.logger.debug(
-                    "model instance%s changed during training; rebuilding dependency graph",
-                    "" if model_changed else " not",
-                )
-                self.pruning_method.analyze_model()
-                if not model_changed and saved[0] is not None:
-                    self.pruning_method.activations = saved[0]
-                    self.pruning_method.layer_shapes = saved[1]
-                    self.pruning_method.num_activations = saved[2]
-                    self.pruning_method.labels = saved[3]
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["finetune"] = metrics

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -75,11 +75,6 @@ class TrainStep(PipelineStep):
                 context.logger.debug("updated pruning method model reference")
             except Exception:  # pragma: no cover - best effort
                 pass
-            if hasattr(pm, "analyze_model"):
-                context.logger.debug(
-                    "model instance changed during training; rebuilding dependency graph"
-                )
-                pm.analyze_model()
         context.metrics_mgr.record_training(metrics or {})
         context.metrics[self.phase] = metrics or {}
         context.logger.info("Finished %s", step)

--- a/tests/test_pipeline_inplace_layer_change.py
+++ b/tests/test_pipeline_inplace_layer_change.py
@@ -81,6 +81,7 @@ method.example_inputs = torch.randn(1,3,8,8)
 pipeline.analyze_structure()
 method.remove_hooks()
 pipeline.pretrain()
+pipeline.analyze_structure()
 for _ in range(2):
     pipeline.model.model(torch.randn(1,3,8,8))
     method.add_labels(torch.tensor([1.0]))

--- a/tests/test_pruning_method_model_update.py
+++ b/tests/test_pruning_method_model_update.py
@@ -51,7 +51,11 @@ def test_pruning_method_model_updated_after_training():
     pipeline.model = DummyYOLO()
     pipeline.pretrain()
     assert pipeline.pruning_method.model is pipeline.model.model
+    assert method.calls == 0
+    pipeline.analyze_structure()
     assert method.calls == 1
     pipeline.finetune()
     assert pipeline.pruning_method.model is pipeline.model.model
+    assert method.calls == 1
+    pipeline.analyze_structure()
     assert method.calls == 2

--- a/tests/test_pruning_method_preserve_records.py
+++ b/tests/test_pruning_method_preserve_records.py
@@ -59,8 +59,11 @@ def test_records_preserved_when_model_unchanged():
     pipeline = pp.PruningPipeline('m', 'd', pruning_method=method)
     pipeline.model = DummyYOLO()
     pipeline.pretrain()
+    assert method.calls == 0
+    pipeline.analyze_structure()
     assert method.calls == 1
-    assert method.activations == {0: [0]}
+    assert method.activations == {}
     pipeline.finetune()
+    assert method.calls == 1
+    pipeline.analyze_structure()
     assert method.calls == 2
-    assert method.activations == {0: [0]}

--- a/tests/test_train_step_auto_analyze.py
+++ b/tests/test_train_step_auto_analyze.py
@@ -82,6 +82,7 @@ from pipeline import (
     LoadModelStep,
     AnalyzeModelStep,
     TrainStep,
+    AnalyzeAfterTrainingStep,
     GenerateMasksStep,
     ApplyPruningStep,
 )
@@ -96,13 +97,14 @@ steps = [
     LoadModelStep(),
     AnalyzeModelStep(),
     TrainStep('pretrain', epochs=1, plots=False),
+    AnalyzeAfterTrainingStep(),
     GenerateMasksStep(ratio=0.5),
     ApplyPruningStep(),
 ]
 
 for step in steps:
     step.run(ctx)
-    if isinstance(step, TrainStep):
+    if isinstance(step, AnalyzeAfterTrainingStep):
         for _ in range(2):
             batch = {{"img": torch.randn(1,3,8,8), "cls": torch.tensor([1.0])}}
             ctx.model.model(batch["img"])


### PR DESCRIPTION
## Summary
- rerun analyze_model with `AnalyzeAfterTrainingStep`
- execute post-training analysis and short forward pass in `execute_pipeline`
- disable automatic analysis in `TrainStep` and pruning pipeline
- update README instructions and pipeline docs
- adjust tests for new explicit analysis workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6853109bedd483249ce566bf99dc4acf