### PR TITLE
Add snapshot saving and reconfiguration output

### DIFF
--- a/pipeline/step/apply_pruning.py
+++ b/pipeline/step/apply_pruning.py
@@ -14,6 +14,12 @@ class ApplyPruningStep(PipelineStep):
             raise NotImplementedError
         context.logger.info("Applying pruning mask")
         context.pruning_method.apply_pruning()
+        snapshot = context.workdir / "snapshot.pt"
+        try:
+            context.logger.info("Saving snapshot to %s", snapshot)
+            context.model.save(str(snapshot))
+        except Exception:  # pragma: no cover - best effort
+            pass
         context.logger.info("Finished %s", step)
 
 __all__ = ["ApplyPruningStep"]

--- a/tests/test_baseline_skip_pipeline.py
+++ b/tests/test_baseline_skip_pipeline.py
@@ -131,7 +131,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             pass
         def apply_pruning(self):
             pass
-        def reconfigure_model(self):
+        def reconfigure_model(self, output_path=None):
             pass
         def calc_pruned_stats(self):
             pass
@@ -143,6 +143,8 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             pass
         def save_metrics_csv(self, path):
             return Path(path)
+        def save_model(self, path):
+            Path(path).write_text('x')
 
     monkeypatch.setattr(main, 'PruningPipeline', DummyPipeline)
 

--- a/tests/test_generate_mask_no_baseline.py
+++ b/tests/test_generate_mask_no_baseline.py
@@ -43,6 +43,9 @@ class DummyModel(torch.nn.Module):
     def train(self, *a, **kw):
         return {{}}
 
+    def save(self, path):
+        Path(path).write_text('x')
+
 
 class DummyYOLO:
     def __init__(self, *a, **k):
@@ -54,6 +57,9 @@ class DummyYOLO:
 
     def train(self, *a, **kw):
         return {{}}
+
+    def save(self, path):
+        Path(path).write_text('x')
 
 
 up.utils = utils

--- a/tests/test_snapshot_save.py
+++ b/tests/test_snapshot_save.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import main
+
+class DummyPipeline:
+    def __init__(self, *a, **k):
+        self.workdir = Path(k.get("workdir", ""))
+        self.model = types.SimpleNamespace(
+            model=object(),
+            save=lambda p: Path(p).write_text("model")
+        )
+        self.pruning_method = None
+        self.metrics_mgr = types.SimpleNamespace(
+            to_csv=lambda p: Path(p),
+            record_computation=lambda m: None,
+        )
+    def load_model(self):
+        pass
+    def calc_initial_stats(self):
+        pass
+    def pretrain(self, **kw):
+        pass
+    def analyze_structure(self):
+        pass
+    def set_pruning_method(self, method):
+        self.pruning_method = method
+    def generate_pruning_mask(self, ratio):
+        pass
+    def apply_pruning(self):
+        pass
+    def reconfigure_model(self, output_path=None):
+        self.output_path = output_path
+    def calc_pruned_stats(self):
+        pass
+    def finetune(self, **kw):
+        pass
+    def visualize_results(self):
+        pass
+    def save_pruning_results(self, path):
+        pass
+    def save_metrics_csv(self, path):
+        return Path(path)
+    def save_model(self, path):
+        Path(path).write_text("snap")
+        self.saved = Path(path)
+
+class DummyMethod:
+    def __init__(self, model=None, workdir=None):
+        self.model = model
+
+
+def test_snapshot_and_pruned_model_saved(monkeypatch, tmp_path):
+    monkeypatch.setattr(main, "PruningPipeline", DummyPipeline)
+    monkeypatch.setattr(main, "YOLO", lambda p: types.SimpleNamespace(model=object(), save=lambda x: None))
+    cfg = main.TrainConfig(baseline_epochs=0, finetune_epochs=0, batch_size=1, ratios=[0.2])
+    pipeline, _ = main.execute_pipeline("m", "d", DummyMethod, 0.2, cfg, tmp_path)
+    assert (tmp_path / "snapshot.pt").exists()
+    assert pipeline.saved == tmp_path / "snapshot.pt"
+    assert pipeline.output_path == tmp_path / "pruned_model_DummyMethod_0.2.pt"
+    assert pipeline.pruning_method.model is pipeline.model.model
+


### PR DESCRIPTION
## Summary
- add `save_model` helper in `PruningPipeline`
- write a snapshot after applying pruning
- reload the snapshot before reconfiguring and allow saving reconfigured model
- update `execute_pipeline` to log saved paths
- extend pipeline steps to support snapshot workflow
- adjust tests and add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68532b6ddb0883249dc24c21b428986b