### PR TITLE
Add scikit-learn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Depgraph HSIC Pruning
+
+This repository provides utilities and pruning methods for YOLO models.
+
+## Installation
+
+Install the runtime dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+For running the test suite use:
+
+```bash
+pip install -r requirements-test.txt
+```
+
+### DepgraphHSICMethod
+
+`DepgraphHSICMethod` requires `scikit-learn` for its HSIC-Lasso implementation.
+The package is listed in `requirements.txt`, but if you only installed a subset of
+dependencies make sure `scikit-learn` is available:
+
+```bash
+pip install scikit-learn
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ tqdm>=4.64.0
 psutil
 py-cpuinfo
 pandas>=1.1.4
+scikit-learn>=1.4.0
 ultralytics-thop>=2.0.0
 ultralytics>=8.0.0
 seaborn>=0.12.0


### PR DESCRIPTION
## Summary
- include `scikit-learn` in runtime requirements
- document installation instructions and HSIC dependency in a new `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853e7b69d7c832486fe1bf410d9cc4e