### PR TITLE
Add stub module documentation

### DIFF
--- a/matplotlib/__init__.py
+++ b/matplotlib/__init__.py
@@ -1,0 +1,6 @@
+"""Minimal matplotlib stub for tests.
+
+This package only provides the pieces needed by the unit tests. Install the real
+``matplotlib`` library when running outside the test environment.
+"""
+

--- a/matplotlib/artist.py
+++ b/matplotlib/artist.py
@@ -1,1 +1,6 @@
+"""Stub of :mod:`matplotlib.artist` for tests.
+
+This file contains only enough structure for the test suite. Use the real
+``matplotlib`` package in any production code.
+"""
 

--- a/matplotlib/pyplot/__init__.py
+++ b/matplotlib/pyplot/__init__.py
@@ -1,3 +1,9 @@
+"""Simplified :mod:`matplotlib.pyplot` replacement for testing.
+
+Only provides thin stubs of a few functions. Install the full ``matplotlib``
+package for real plotting capabilities.
+"""
+
 import os
 
 def figure(*a, **k):

--- a/seaborn/__init__.py
+++ b/seaborn/__init__.py
@@ -1,3 +1,9 @@
+"""Minimal :mod:`seaborn` stub for unit tests.
+
+It re-exports only a small ``heatmap`` function wrapper. For real projects
+install the genuine ``seaborn`` package.
+"""
+
 import matplotlib.pyplot as plt
 
 def heatmap(data, *a, **k):

--- a/torch_pruning/__init__.py
+++ b/torch_pruning/__init__.py
@@ -1,3 +1,10 @@
+"""Simplified placeholder for tests.
+
+This stub mimics a tiny portion of the real :mod:`torch_pruning` package so
+the unit tests can run without the actual dependency. Install the real
+``torch-pruning`` library for any production usage.
+"""
+
 import types
 import importlib.metadata as _metadata
 import torch

--- a/torch_pruning/importance/__init__.py
+++ b/torch_pruning/importance/__init__.py
@@ -1,3 +1,10 @@
+"""Simplified importance metrics used for testing.
+
+These classes only serve as placeholders. Install ``torch-pruning`` to access
+the full set of importance measures in real applications.
+"""
+
+
 class RandomImportance:
     pass
 

--- a/torch_pruning/pruner/__init__.py
+++ b/torch_pruning/pruner/__init__.py
@@ -1,3 +1,9 @@
+"""Stub pruner implementations for the unit tests.
+
+They only mimic the interfaces of the real :mod:`torch_pruning` pruners.
+Install ``torch-pruning`` for production-grade pruning algorithms.
+"""
+
 from .algorithms import BasePruner as BasePruner
 
 class RandomPruner(BasePruner):

--- a/torch_pruning/pruner/algorithms/__init__.py
+++ b/torch_pruning/pruner/algorithms/__init__.py
@@ -1,3 +1,9 @@
+"""Algorithmic stubs for pruning used during testing.
+
+Only minimal logic is provided for unit tests. For full functionality install
+the ``torch-pruning`` package.
+"""
+
 import torch
 from torch import nn
 

--- a/torch_pruning/utils.py
+++ b/torch_pruning/utils.py
@@ -1,3 +1,9 @@
+"""Utility stubs for :mod:`torch_pruning` used in the tests.
+
+Only the bare minimum is implemented. Install ``torch-pruning`` for the full
+functionality when running in production.
+"""
+
 
 def remove_pruning_reparametrization(model):
     pass


### PR DESCRIPTION
## Summary
- clarify that toy modules in torch_pruning, matplotlib and seaborn directories are simplified stubs
- note that real libraries should be installed for production use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853e7b8bd0483249b1811f628fc7bc0