### PR TITLE
Enable auto-analysis after training

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -171,6 +171,20 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
+            if model_changed:
+                try:
+                    import torch  # local import to avoid heavy dependency at module import
+                    try:
+                        device = next(self.pruning_method.model.parameters()).device
+                    except Exception:
+                        device = torch.device("cpu") if hasattr(torch, "device") else "cpu"
+                    example_inputs = getattr(self.pruning_method, "example_inputs", None)
+                    if hasattr(torch, "is_tensor") and torch.is_tensor(example_inputs):
+                        self.pruning_method.example_inputs = example_inputs.to(device)
+                    self.pruning_method.analyze_model()
+                    self.logger.debug("reanalyzed pruning method model")
+                except Exception:  # pragma: no cover - best effort
+                    pass
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["pretrain"] = metrics
@@ -281,6 +295,20 @@ class PruningPipeline(BasePruningPipeline):
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             self.logger.debug("updated pruning method model reference")
+            if model_changed:
+                try:
+                    import torch  # local import to avoid heavy dependency at module import
+                    try:
+                        device = next(self.pruning_method.model.parameters()).device
+                    except Exception:
+                        device = torch.device("cpu") if hasattr(torch, "device") else "cpu"
+                    example_inputs = getattr(self.pruning_method, "example_inputs", None)
+                    if hasattr(torch, "is_tensor") and torch.is_tensor(example_inputs):
+                        self.pruning_method.example_inputs = example_inputs.to(device)
+                    self.pruning_method.analyze_model()
+                    self.logger.debug("reanalyzed pruning method model")
+                except Exception:  # pragma: no cover - best effort
+                    pass
         self.logger.debug(metrics)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["finetune"] = metrics

--- a/tests/test_pruning_method_model_update.py
+++ b/tests/test_pruning_method_model_update.py
@@ -51,11 +51,11 @@ def test_pruning_method_model_updated_after_training():
     pipeline.model = DummyYOLO()
     pipeline.pretrain()
     assert pipeline.pruning_method.model is pipeline.model.model
-    assert method.calls == 0
-    pipeline.analyze_structure()
-    assert method.calls == 1
-    pipeline.finetune()
-    assert pipeline.pruning_method.model is pipeline.model.model
     assert method.calls == 1
     pipeline.analyze_structure()
     assert method.calls == 2
+    pipeline.finetune()
+    assert pipeline.pruning_method.model is pipeline.model.model
+    assert method.calls == 3
+    pipeline.analyze_structure()
+    assert method.calls == 4


### PR DESCRIPTION
## Summary
- detect training that replaces the YOLO model
- when training swaps the model, move example inputs to the new device and rebuild the dependency graph
- update tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68540b30b538832493e2b73514cb1527