### PR TITLE
Refresh dependency graph before pruning

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -185,6 +185,8 @@ class PruningPipeline2(BasePruningPipeline):
         self.logger.info("Applying pruning via DependencyGraph")
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
+            self.pruning_method.refresh_dependency_graph()
+            self.logger.info("Dependency graph refreshed before pruning")
         self.pruning_method.apply_pruning()
         try:
             import torch_pruning as tp

--- a/tests/test_pipeline2_refresh.py
+++ b/tests/test_pipeline2_refresh.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def test_refresh_dependency_graph_called(monkeypatch):
+    tp = types.ModuleType('torch_pruning')
+    tp.utils = types.SimpleNamespace(remove_pruning_reparametrization=lambda m: None)
+    monkeypatch.setitem(sys.modules, 'torch_pruning', tp)
+
+    up = types.ModuleType('ultralytics')
+    utils = types.ModuleType('ultralytics.utils')
+    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+    torch_utils.get_flops = lambda *a, **k: 0
+    torch_utils.get_num_params = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
+    up.utils = utils
+    up.YOLO = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
+
+    pp = importlib.import_module('pipeline.pruning_pipeline_2')
+    importlib.reload(pp)
+
+    calls = []
+
+    class DummyMethod:
+        def __init__(self, model=None, **kw):
+            self.model = model
+        def refresh_dependency_graph(self):
+            calls.append('refresh')
+        def apply_pruning(self):
+            calls.append('apply')
+
+    monkeypatch.setattr(pp, 'DepgraphHSICMethod', DummyMethod)
+
+    pipeline = pp.PruningPipeline2('m', 'd', pruning_method=DummyMethod(None))
+    pipeline.model = types.SimpleNamespace(model=object())
+
+    pipeline.apply_pruning()
+
+    assert calls == ['refresh', 'apply']


### PR DESCRIPTION
## Summary
- add `refresh_dependency_graph` to `DepgraphHSICMethod`
- refresh dependency graph before pruning in `PruningPipeline2`
- test that `refresh_dependency_graph` is invoked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68543ff1aa8c83249b7716de34342f57