### PR TITLE
Improve logging around dependency graph

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -210,6 +210,7 @@ class PruningPipeline2(BasePruningPipeline):
         self.logger.info("Applying pruning via DependencyGraph")
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
+            self.logger.debug("Refreshing dependency graph before pruning")
             self.pruning_method.refresh_dependency_graph()
             self.logger.info("Dependency graph refreshed before pruning")
         self.pruning_method.apply_pruning()

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -394,6 +394,14 @@ class DepgraphHSICMethod(BasePruningMethod):
         self.DG = tp.DependencyGraph()
         try:
             self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
+            named_modules = dict(self.model.named_modules())
+            self.logger.debug(
+                "Dependency graph captured %d modules", len(named_modules)
+            )
+            self.logger.debug(
+                "Dependency graph modules: %s", list(named_modules.keys())
+            )
+            self.logger.debug("Pruning layers: %s", self.layer_names)
             saved = (
                 self.activations,
                 self.layer_shapes,
@@ -414,6 +422,14 @@ class DepgraphHSICMethod(BasePruningMethod):
             self.analyze_model()
             self.activations, self.layer_shapes, self.num_activations, self.labels = saved
             self.DG.build_dependency(self.model, example_inputs=self._inputs_tuple())
+            named_modules = dict(self.model.named_modules())
+            self.logger.debug(
+                "Dependency graph captured %d modules", len(named_modules)
+            )
+            self.logger.debug(
+                "Dependency graph modules: %s", list(named_modules.keys())
+            )
+            self.logger.debug("Pruning layers: %s", self.layer_names)
             saved = (
                 self.activations,
                 self.layer_shapes,
@@ -445,6 +461,12 @@ class DepgraphHSICMethod(BasePruningMethod):
                     )
                 except ValueError as e:
                     self.logger.debug("get_pruning_group failed: %s", e)
+                    self.logger.debug(
+                        "Analyzed layers: %s", self.layer_names
+                    )
+                    self.logger.debug(
+                        "Requested layer present: %s", name in self.layer_names
+                    )
                     self.logger.info("Rebuilding dependency graph before pruning")
                     # recreate the DependencyGraph in case the model changed
                     self.DG = tp.DependencyGraph()
@@ -484,6 +506,12 @@ class DepgraphHSICMethod(BasePruningMethod):
                     except ValueError as err:
                         self.logger.error(
                             "get_pruning_group failed again for %s: %s", name, err
+                        )
+                        self.logger.debug(
+                            "Analyzed layers: %s", self.layer_names
+                        )
+                        self.logger.debug(
+                            "Requested layer present: %s", name in self.layer_names
                         )
                         self.logger.debug(
                             "Analyzing model and rebuilding dependency graph for final retry"
@@ -530,6 +558,12 @@ class DepgraphHSICMethod(BasePruningMethod):
                         except ValueError as err2:
                             self.logger.error(
                                 "get_pruning_group failed third time for %s: %s", name, err2
+                            )
+                            self.logger.debug(
+                                "Analyzed layers: %s", self.layer_names
+                            )
+                            self.logger.debug(
+                                "Requested layer present: %s", name in self.layer_names
                             )
                             try:
                                 model_device = next(self.model.parameters()).device


### PR DESCRIPTION
## Summary
- show which modules are in the dependency graph during pruning
- report analysed layers when get_pruning_group fails
- log refresh operations in `PruningPipeline2.apply_pruning`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854485e0e088324ba1441eb2c793f5e