### PR TITLE
Rebuild graph after pretrain

### DIFF
--- a/tests/test_pipeline2_device_sync.py
+++ b/tests/test_pipeline2_device_sync.py
@@ -57,6 +57,8 @@ def setup_modules(monkeypatch):
             self.example_inputs = DummyTensor('cpu')
         def refresh_dependency_graph(self):
             pass
+        def analyze_model(self):
+            pass
         def apply_pruning(self):
             pass
     hsic.DepgraphHSICMethod = DummyMethod


### PR DESCRIPTION
## Summary
- sync example_inputs and rebuild the DependencyGraph after pretrain
- log how many convolution layers were registered
- adjust dummy pruning method for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68544e65d39083248bb357f321e22560