### PR TITLE
Refresh graph before HSIC steps

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -187,6 +187,10 @@ class PruningPipeline2(BasePruningPipeline):
         if not isinstance(self.pruning_method, DepgraphHSICMethod):
             raise NotImplementedError
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
+        if self.pruning_method is not None:
+            self.pruning_method.model = self.model.model
+            self.logger.info("Reanalyzing model before mask generation")
+            self.pruning_method.analyze_model()
         self.pruning_method.generate_pruning_mask(ratio)
         channels = sum(len(v) for v in getattr(self.pruning_method, "pruning_plan", {}).values())
         total = sum(
@@ -207,9 +211,8 @@ class PruningPipeline2(BasePruningPipeline):
         self.logger.info("Applying pruning via DependencyGraph")
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
-            self.logger.debug("Refreshing dependency graph before pruning")
-            self.pruning_method.refresh_dependency_graph()
-            self.logger.info("Dependency graph refreshed before pruning")
+            self.logger.info("Reanalyzing model before pruning")
+            self.pruning_method.analyze_model()
         self.pruning_method.apply_pruning()
         try:
             import torch_pruning as tp

--- a/tests/test_pipeline2_refresh.py
+++ b/tests/test_pipeline2_refresh.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 
-def test_refresh_dependency_graph_called(monkeypatch):
+def test_analyze_model_called(monkeypatch):
     tp = types.ModuleType('torch_pruning')
     tp.utils = types.SimpleNamespace(remove_pruning_reparametrization=lambda m: None)
     monkeypatch.setitem(sys.modules, 'torch_pruning', tp)
@@ -30,8 +30,8 @@ def test_refresh_dependency_graph_called(monkeypatch):
     class DummyMethod:
         def __init__(self, model=None, **kw):
             self.model = model
-        def refresh_dependency_graph(self):
-            calls.append('refresh')
+        def analyze_model(self):
+            calls.append('analyze')
         def apply_pruning(self):
             calls.append('apply')
 
@@ -42,4 +42,4 @@ def test_refresh_dependency_graph_called(monkeypatch):
 
     pipeline.apply_pruning()
 
-    assert calls == ['refresh', 'apply']
+    assert calls == ['analyze', 'apply']


### PR DESCRIPTION
## Summary
- ensure the HSIC pruning pipeline reanalyses the model before generating masks or pruning
- update pipeline2 refresh test accordingly

## Testing
- `pytest -k pipeline2_refresh -q`

------
https://chatgpt.com/codex/tasks/task_b_6854505b1ab483249d8b66328f05387a