### PR TITLE
Fix logger handler replacement

### DIFF
--- a/helper/logger.py
+++ b/helper/logger.py
@@ -41,12 +41,14 @@ class Logger:
 
 
 def add_file_handler(logger: Logger, log_file: str) -> None:
-    """Attach a :class:`logging.FileHandler` to ``logger`` if missing."""
-    if not any(isinstance(h, logging.FileHandler) for h in logger.logger.handlers):
-        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-        handler = logging.FileHandler(log_file)
-        handler.setFormatter(formatter)
-        logger.logger.addHandler(handler)
+    """Attach a :class:`logging.FileHandler` to ``logger`` replacing any existing ones."""
+    for h in list(logger.logger.handlers):
+        if isinstance(h, logging.FileHandler):
+            logger.logger.removeHandler(h)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler = logging.FileHandler(log_file)
+    handler.setFormatter(formatter)
+    logger.logger.addHandler(handler)
 
 
 def get_logger(

--- a/main.py
+++ b/main.py
@@ -180,6 +180,9 @@ def execute_pipeline(
     if logger is None:
         logger = get_logger(log_file=str(log_file))
     else:
+        for h in list(logger.logger.handlers):
+            if isinstance(h, logging.FileHandler):
+                logger.logger.removeHandler(h)
         add_file_handler(logger, str(log_file))
     if method_cls is not None and issubclass(method_cls, DepgraphHSICMethod):
         pipeline_cls: type[BasePruningPipeline] = PruningPipeline2


### PR DESCRIPTION
## Summary
- always replace existing log file handlers
- clear old file handlers before running pipeline

## Testing
- `pytest tests/test_logger_file.py::test_log_file_created_with_logger -q`
- `pytest -q` *(fails: test_generate_mask_no_baseline)*

------
https://chatgpt.com/codex/tasks/task_b_68545b1f24a08324a1e62dd47e18f4fe