### PR TITLE
Ensure DepgraphHSIC analysis before pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ pip install scikit-learn
 Run `main.py` to train and prune a YOLO model. Specify the computation device
 with the `--device` option. If the loaded model supports `.to()`, it will be
 moved to that device automatically.
+
+When using `DepgraphHSICMethod`, ensure that `analyze_structure()` is run after every training phase. The `execute_pipeline` helper automatically performs this analysis just before pruning mask generation.

--- a/main.py
+++ b/main.py
@@ -268,6 +268,9 @@ def execute_pipeline(
             except Exception as exc:  # pragma: no cover - best effort
                 logger.warning("short forward pass failed: %s", exc)
     if method_cls is not None:
+        if isinstance(getattr(pipeline, "pruning_method", None), DepgraphHSICMethod):
+            # Ensure analysis runs on the latest model state before mask generation
+            pipeline.analyze_structure()
         pipeline.generate_pruning_mask(ratio)
         pipeline.apply_pruning()
         snapshot = workdir / "snapshot.pt"


### PR DESCRIPTION
## Summary
- call `analyze_structure()` automatically before generating pruning masks when using `DepgraphHSICMethod`
- document analysis requirement for HSIC pruning in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68546e9c29d48324b8f137c4325f12eb