### PR TITLE
Fix label counting before reanalysis

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -168,6 +168,8 @@ class PruningPipeline2(BasePruningPipeline):
         metrics = self.model.train(data=self.data, device=device, **train_kwargs)
         self._unregister_label_callback()
 
+        num_labels = len(getattr(self.pruning_method, "labels", []))
+
         if self.pruning_method is not None:
             self.pruning_method.model = self.model.model
             try:
@@ -182,7 +184,6 @@ class PruningPipeline2(BasePruningPipeline):
             except Exception:
                 pass
 
-        num_labels = len(getattr(self.pruning_method, "labels", []))
         self.logger.info("Training finished; recorded %d label batches", num_labels)
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["pretrain"] = metrics or {}

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -260,7 +260,7 @@ class DepgraphHSICMethod(BasePruningMethod):
 
     def _log_dependency_status(self) -> None:
         """Report which layers were mapped to pruners in the current graph."""
-        if self.DG is None:
+        if self.DG is None or not hasattr(self.DG, "get_pruner_of_module"):
             return
         mapped = []
         for layer, name in zip(self.layers, self.layer_names):


### PR DESCRIPTION
## Summary
- count DepgraphHSIC label batches before reanalysing the model
- avoid _log_dependency_status failure if the dependency graph stub lacks `get_pruner_of_module`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854f870e1a4832490eca9a1545ba8bd