### PR TITLE
Add pipeline2 model update test

### DIFF
--- a/tests/test_pruning_pipeline2_model_update.py
+++ b/tests/test_pruning_pipeline2_model_update.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# ensure real torch is available
+import torch  # noqa: F401
+
+up = types.ModuleType('ultralytics')
+utils = types.ModuleType('ultralytics.utils')
+torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+torch_utils.get_flops = lambda *a, **k: 0
+torch_utils.get_num_params = lambda *a, **k: 0
+utils.torch_utils = torch_utils
+
+class DummyYOLO:
+    def __init__(self):
+        self.model = types.SimpleNamespace(id=0)
+        self.callbacks = {}
+    def add_callback(self, event, cb):
+        self.callbacks.setdefault(event, []).append(cb)
+    def train(self, *a, **k):
+        self.model = types.SimpleNamespace(id=self.model.id + 1)
+        return {}
+
+up.utils = utils
+up.YOLO = lambda *a, **k: DummyYOLO()
+sys.modules['ultralytics'] = up
+sys.modules['ultralytics.utils'] = utils
+sys.modules['ultralytics.utils.torch_utils'] = torch_utils
+
+hsic_mod = types.ModuleType('prune_methods.depgraph_hsic')
+class DummyMethod:
+    def __init__(self, model=None, **kw):
+        self.model = model
+        self.calls = 0
+        self.labels = []
+    def analyze_model(self):
+        self.calls += 1
+hsic_mod.DepgraphHSICMethod = DummyMethod
+sys.modules['prune_methods.depgraph_hsic'] = hsic_mod
+
+import importlib
+pp = importlib.import_module('pipeline.pruning_pipeline_2')
+pp.YOLO = up.YOLO
+pp.DepgraphHSICMethod = DummyMethod
+
+
+def test_pruning_pipeline2_model_updated_after_training():
+    method = DummyMethod(None)
+    pipeline = pp.PruningPipeline2('m', 'd', pruning_method=method)
+    pipeline.model = DummyYOLO()
+    pipeline.pretrain()
+    assert pipeline.pruning_method.model is pipeline.model.model
+    assert method.calls == 1
+    pipeline.analyze_structure()
+    assert method.calls == 2
+    pipeline.finetune()
+    assert pipeline.pruning_method.model is pipeline.model.model
+    assert method.calls == 3
+    pipeline.analyze_structure()
+    assert method.calls == 4


### PR DESCRIPTION
## Summary
- create `tests/test_pruning_pipeline2_model_update.py` to verify that `pretrain` and `finetune` update the pruning method model
- ensure analyze_structure can run without errors using simple stubs

## Testing
- `pytest -k pruning_pipeline2_model_update -q`

------
https://chatgpt.com/codex/tasks/task_b_6854fbc2e05c83248031d6d6059bf432