### PR TITLE
Remove redundant reparametrization cleanup

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -240,11 +240,6 @@ class PruningPipeline2(BasePruningPipeline):
             self.logger.info("Reanalyzing model before pruning")
             self.pruning_method.analyze_model()
         self.pruning_method.apply_pruning()
-        try:
-            import torch_pruning as tp
-            tp.utils.remove_pruning_reparametrization(self.model.model)
-        except Exception as exc:  # pragma: no cover - optional dependency
-            self.logger.debug("remove_pruning_reparametrization failed: %s", exc)
         pruned = sum(len(v) for v in getattr(self.pruning_method, "pruning_plan", {}).values())
         self.logger.info("Pruning applied; %d channels pruned", pruned)
 

--- a/tests/test_pipeline_remove_reparam.py
+++ b/tests/test_pipeline_remove_reparam.py
@@ -1,0 +1,91 @@
+import subprocess, sys, types
+from pathlib import Path
+
+def test_pipeline_remove_pruning_reparam_called_once(tmp_path):
+    code = f"""
+import torch, types, sys
+
+sys.modules['matplotlib'] = types.ModuleType('matplotlib')
+sys.modules['matplotlib.pyplot'] = types.ModuleType('matplotlib.pyplot')
+
+class DummyGroup(list):
+    def __init__(self, conv, idxs):
+        super().__init__([(types.SimpleNamespace(target=types.SimpleNamespace(module=conv)), idxs)])
+        self.conv = conv
+    def prune(self):
+        self.conv.reparam = True
+
+class DummyDG:
+    def build_dependency(self, model, example_inputs=None):
+        pass
+    def get_pruning_group(self, conv, fn, idxs):
+        return DummyGroup(conv, idxs)
+
+tp = types.ModuleType('torch_pruning')
+tp.DependencyGraph = DummyDG
+tp.prune_conv_out_channels = lambda *a, **k: None
+calls = []
+
+def remove_pruning_reparametrization(model):
+    calls.append(model)
+    for m in model.modules():
+        if hasattr(m, 'reparam'):
+            delattr(m, 'reparam')
+
+tp.utils = types.SimpleNamespace(remove_pruning_reparametrization=remove_pruning_reparametrization)
+sys.modules['torch_pruning'] = tp
+
+class DummyYOLO:
+    def __init__(self):
+        self.model = torch.nn.Sequential(
+            torch.nn.Conv2d(3, 4, 3),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(4, 8, 3),
+            torch.nn.ReLU(),
+        )
+        self.callbacks = {{}}
+    def add_callback(self, event, cb):
+        self.callbacks.setdefault(event, []).append(cb)
+
+up = types.ModuleType('ultralytics')
+utils = types.ModuleType('ultralytics.utils')
+torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+torch_utils.get_flops = lambda *a, **k: 0
+torch_utils.get_num_params = lambda *a, **k: 0
+utils.torch_utils = torch_utils
+up.utils = utils
+up.YOLO = lambda *a, **k: DummyYOLO()
+sys.modules['ultralytics'] = up
+sys.modules['ultralytics.utils'] = utils
+sys.modules['ultralytics.utils.torch_utils'] = torch_utils
+
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+from pipeline.pruning_pipeline_2 import PruningPipeline2
+import types as t
+
+method = DepgraphHSICMethod(None, workdir='{tmp_path}')
+method.example_inputs = torch.randn(1, 3, 8, 8)
+method.logger = types.SimpleNamespace(info=lambda *a, **k: None, debug=lambda *a, **k: None, warning=lambda *a, **k: None)
+
+def analyze_stub(self):
+    self.DG = DummyDG()
+    self._dg_model = self.model
+    self.layers = [self.model[0]]
+    self.layer_names = ['0']
+
+method.analyze_model = t.MethodType(analyze_stub, method)
+method.pruning_plan = {{'0': [0]}}
+
+pipeline = PruningPipeline2('m', 'd', pruning_method=method)
+pipeline.model = DummyYOLO()
+method.model = pipeline.model.model
+
+pipeline.apply_pruning()
+
+print(len(calls))
+print(hasattr(pipeline.model.model[0], 'reparam'))
+"""
+    out = subprocess.check_output([sys.executable, '-c', code])
+    calls_count, has_reparam = out.decode().strip().splitlines()
+    assert calls_count == '1'
+    assert has_reparam == 'False'


### PR DESCRIPTION
## Summary
- prune_methods.DepgraphHSICMethod already strips `torch-pruning` reparametrization
- avoid repeating this logic in `PruningPipeline2`
- add regression test checking the pipeline only removes reparametrization once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685516cfffc8832494470f42cca6430a