### PR TITLE
Pass dataloader to pruning mask generation

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -203,12 +203,18 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Analyzing model structure")
         self.pruning_method.analyze_model()
 
-    def generate_pruning_mask(self, ratio: float) -> None:
+    def generate_pruning_mask(self, ratio: float, dataloader=None) -> None:
         """Generate pruning mask at ``ratio`` sparsity."""
         if self.pruning_method is None:
             raise NotImplementedError
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
-        self.pruning_method.generate_pruning_mask(ratio)
+        if dataloader is None:
+            try:
+                trainer = getattr(self.model, "trainer", None)
+                dataloader = getattr(trainer, "train_loader", None) or getattr(trainer, "train_dataloader", None) or getattr(trainer, "val_loader", None) or getattr(trainer, "val_dataloader", None)
+            except Exception:  # pragma: no cover - best effort
+                dataloader = None
+        self.pruning_method.generate_pruning_mask(ratio, dataloader)
 
     def apply_pruning(self) -> None:
         """Apply the previously generated pruning mask to the model."""

--- a/pipeline/step/generate_masks.py
+++ b/pipeline/step/generate_masks.py
@@ -7,8 +7,9 @@ from . import PipelineStep
 class GenerateMasksStep(PipelineStep):
     """Generate pruning masks at a given sparsity ratio."""
 
-    def __init__(self, ratio: float) -> None:
+    def __init__(self, ratio: float, dataloader=None) -> None:
         self.ratio = ratio
+        self.dataloader = dataloader
 
     def run(self, context: PipelineContext) -> None:
         step = self.__class__.__name__
@@ -16,7 +17,7 @@ class GenerateMasksStep(PipelineStep):
         if context.pruning_method is None:
             raise NotImplementedError
         context.logger.info("Generating pruning mask at ratio %.2f", self.ratio)
-        context.pruning_method.generate_pruning_mask(self.ratio)
+        context.pruning_method.generate_pruning_mask(self.ratio, self.dataloader)
         context.logger.info("Finished %s", step)
 
 __all__ = ["GenerateMasksStep"]

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -356,7 +356,7 @@ class DepgraphHSICMethod(BasePruningMethod):
         self._build_adjacency()
         self._build_channel_groups()
 
-    def generate_pruning_mask(self, ratio: float) -> None:
+    def generate_pruning_mask(self, ratio: float, dataloader=None) -> None:
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         if not self.activations or not self.labels:
             self.logger.debug(

--- a/tests/test_baseline_skip_pipeline.py
+++ b/tests/test_baseline_skip_pipeline.py
@@ -96,7 +96,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             DummyMethod.calls = []
         def analyze_model(self):
             DummyMethod.calls.append('analyze')
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             DummyMethod.calls.append('mask')
         def apply_pruning(self):
             DummyMethod.calls.append('apply')
@@ -127,7 +127,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             DummyMethod.calls.append('pipeline_analyze')
         def set_pruning_method(self, method):
             self.pruning_method = method
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
         def apply_pruning(self):
             pass

--- a/tests/test_execute_pipeline_device.py
+++ b/tests/test_execute_pipeline_device.py
@@ -64,7 +64,7 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
             pass
         def set_pruning_method(self, method):
             self.pruning_method = method
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
         def apply_pruning(self):
             pass
@@ -88,7 +88,7 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
             self.model = model
         def analyze_model(self):
             pass
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
         def apply_pruning(self):
             pass

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -38,7 +38,7 @@ def test_log_file_created_with_logger(tmp_path, monkeypatch):
         def analyze_structure(self):
             pass
 
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
 
         def apply_pruning(self):

--- a/tests/test_pipeline_loader.py
+++ b/tests/test_pipeline_loader.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import types
+
+
+def setup(monkeypatch, loader):
+    up = types.ModuleType('ultralytics')
+    utils = types.ModuleType('ultralytics.utils')
+    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+    torch_utils.get_flops = lambda *a, **k: 0
+    torch_utils.get_num_params = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
+
+    class DummyYOLO:
+        def __init__(self):
+            self.model = types.SimpleNamespace()
+            self.callbacks = {}
+            self.trainer = types.SimpleNamespace(val_loader=loader)
+        def add_callback(self, event, cb):
+            pass
+    up.utils = utils
+    up.YOLO = lambda *a, **k: DummyYOLO()
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
+
+    hsic_mod = types.ModuleType('prune_methods.depgraph_hsic')
+    class Base:
+        def __init__(self, model=None, **kw):
+            self.model = model
+    hsic_mod.DepgraphHSICMethod = Base
+    monkeypatch.setitem(sys.modules, 'prune_methods.depgraph_hsic', hsic_mod)
+
+    pp = importlib.import_module('pipeline.pruning_pipeline_2')
+    importlib.reload(pp)
+    return pp, hsic_mod.DepgraphHSICMethod
+
+
+def test_loader_passed(monkeypatch):
+    loader = object()
+    pp, Base = setup(monkeypatch, loader)
+
+    calls = []
+
+    class DummyMethod(Base):
+        def __init__(self, model=None, **kw):
+            super().__init__(model)
+        def analyze_model(self):
+            pass
+        def generate_pruning_mask(self, ratio, dataloader=None):
+            calls.append(dataloader)
+        def apply_pruning(self):
+            pass
+
+    pipeline = pp.PruningPipeline2('m', 'd', pruning_method=DummyMethod(None))
+    pipeline.load_model()
+    pipeline.generate_pruning_mask(0.5)
+    assert calls == [loader]

--- a/tests/test_reuse_baseline.py
+++ b/tests/test_reuse_baseline.py
@@ -38,7 +38,7 @@ class DummyPipeline:
         pass
     def analyze_structure(self):
         pass
-    def generate_pruning_mask(self, ratio):
+    def generate_pruning_mask(self, ratio, dataloader=None):
         pass
     def apply_pruning(self):
         pass

--- a/tests/test_snapshot_save.py
+++ b/tests/test_snapshot_save.py
@@ -29,7 +29,7 @@ class DummyPipeline:
         pass
     def set_pruning_method(self, method):
         self.pruning_method = method
-    def generate_pruning_mask(self, ratio):
+    def generate_pruning_mask(self, ratio, dataloader=None):
         pass
     def apply_pruning(self):
         pass


### PR DESCRIPTION
## Summary
- let pipeline mask generation forward a dataloader when available
- update dependency-based method signature to accept a dataloader
- adapt GenerateMasksStep and tests for optional loader
- add regression test verifying loader forwarding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68569b0495748324a2f137ce6a48d971