### PR TITLE
Improve README pruning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ with the `--device` option. If the loaded model supports `.to()`, it will be
 moved to that device automatically.
 
 When using `DepgraphHSICMethod`, ensure that `analyze_structure()` is run after every training phase. The `execute_pipeline` helper automatically performs this analysis just before pruning mask generation.
+
+`DepgraphHSICMethod.apply_pruning` relies on `torch_pruning`'s
+`DependencyGraph` to remove pruned channels. If layers are replaced or
+reconstructed during training, the method rebuilds the graph
+automatically, so you generally do not need to manually adjust the
+model before pruning.
+
+Example usage:
+
+```python
+method.generate_pruning_mask(0.5, dataloader=train_loader)
+method.apply_pruning()
+```


### PR DESCRIPTION
## Summary
- document that `apply_pruning` relies on `torch_pruning` dependency graph
- show how to call `generate_pruning_mask(dataloader=...)` and `apply_pruning`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68569fd4e20883249d72b79ed714b322