### PR TITLE
Sync pruning before applying

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ When using `DepgraphHSICMethod`, ensure that `analyze_structure()` is run after 
 `DependencyGraph` to remove pruned channels. If layers are replaced or
 reconstructed during training, the method rebuilds the graph
 automatically, so you generally do not need to manually adjust the
-model before pruning.  Should pruning fail because a layer is reported
-as missing from the dependency graph, rerun
-``apply_pruning(rebuild=True)`` to rebuild the graph before applying the
-mask.
+model before pruning. Always call `analyze_model()` before applying the
+pruning plan or invoke ``apply_pruning(rebuild=True)`` to rebuild the
+graph automatically. Should pruning fail because a layer is reported as
+missing from the dependency graph, rerun ``apply_pruning(rebuild=True)``
+to rebuild the graph before applying the mask.
 
 Example usage:
 

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -259,9 +259,9 @@ class PruningPipeline2(BasePruningPipeline):
             raise NotImplementedError
         self.logger.info("Applying pruning via DependencyGraph")
         if self.pruning_method is not None:
-            self._sync_pruning_method(reanalyze=True)
-
             plan = getattr(self.pruning_method, "pruning_plan", [])
+            # always resync right before applying pruning
+            self._sync_pruning_method(reanalyze=True)
             if isinstance(plan, dict):
                 named = dict(self.model.model.named_modules())
                 try:


### PR DESCRIPTION
## Summary
- ensure ApplyPruningStep synchronizes the pruning method with the model
- re-sync PruningPipeline2 before pruning
- document that analyze_model must run before apply_pruning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6856d9246ba0832496f983333e2ff0ea