### PR TITLE
Ensure pruning always removes at least one group

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -349,8 +349,8 @@ class DepgraphHSICMethod(BasePruningMethod):
                 score = importance[idxs].mean().item()
                 scored_groups.append((score, g))
         scored_groups.sort(key=lambda x: x[0])
-        keep = int(len(scored_groups) * ratio)
-        self.pruning_plan = [g for _, g in scored_groups[:keep]]
+        num_to_prune = max(1, int(len(scored_groups) * ratio)) if ratio > 0 else 0
+        self.pruning_plan = [g for _, g in scored_groups[:num_to_prune]]
 
     def apply_pruning(self, rebuild: bool = False) -> None:  # pragma: no cover - heavy dependency
         self.logger.info("Applying pruning")

--- a/tests/test_hsic_minimum_pruning_ratio.py
+++ b/tests/test_hsic_minimum_pruning_ratio.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_generate_pruning_mask_minimum(tmp_path):
+    code = f"""
+import json
+import sys
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.example_inputs = torch.randn(1, 3, 8, 8)
+method.analyze_model()
+for _ in range(2):
+    model(torch.randn(1, 3, 8, 8))
+    method.add_labels(torch.tensor([1.0]))
+method.generate_pruning_mask(0.05)
+json.dump(len(method.pruning_plan), sys.stdout)
+"""
+    out = subprocess.check_output([sys.executable, "-c", code], text=True)
+    count = json.loads(out)
+    assert count == 1


### PR DESCRIPTION
## Summary
- ensure `DepgraphHSICMethod.generate_pruning_mask` prunes at least one group when ratio > 0
- new unit test for minimum pruning ratio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856f81c58348324be77970c6798f90c