### PR TITLE
Call remove_hooks during pruning

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -313,6 +313,10 @@ class PruningPipeline2(BasePruningPipeline):
                 tp.utils.remove_pruning_reparametrization(self.model.model)
             except Exception:  # pragma: no cover - torch_pruning optional
                 pass
+            try:
+                self.pruning_method.remove_hooks()
+            except Exception:
+                pass
 
         plan = getattr(self.pruning_method, "pruning_plan", [])
         if isinstance(plan, dict):


### PR DESCRIPTION
## Summary
- remove hooks after applying pruning plan in `PruningPipeline2`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856fae4ad648324bbead6cb4b5b6059