### PR TITLE
Call remove_hooks at end of ApplyPruningStep

### DIFF
--- a/pipeline/step/apply_pruning.py
+++ b/pipeline/step/apply_pruning.py
@@ -61,6 +61,10 @@ class ApplyPruningStep(PipelineStep):
             tp.utils.remove_pruning_reparametrization(context.model.model)
         except Exception:  # pragma: no cover - optional dependency
             pass
+        try:
+            context.pruning_method.remove_hooks()
+        except Exception:
+            pass
         snapshot = context.workdir / "snapshot.pt"
         try:
             context.logger.info("Saving snapshot to %s", snapshot)


### PR DESCRIPTION
## Summary
- invoke `context.pruning_method.remove_hooks()` in `ApplyPruningStep` after pruning reparameterisation is removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856fd77854c8324b8cf1f073c223a01