### PR TITLE
Remove dataloader param from HSIC mask generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ to rebuild the graph before applying the mask.
 Example usage:
 
 ```python
-method.generate_pruning_mask(0.5, dataloader=train_loader)
+method.generate_pruning_mask(0.5)
 method.apply_pruning()
 ```

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -203,18 +203,12 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Analyzing model structure")
         self.pruning_method.analyze_model()
 
-    def generate_pruning_mask(self, ratio: float, dataloader=None) -> None:
+    def generate_pruning_mask(self, ratio: float) -> None:
         """Generate pruning mask at ``ratio`` sparsity."""
         if self.pruning_method is None:
             raise NotImplementedError
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
-        if dataloader is None:
-            try:
-                trainer = getattr(self.model, "trainer", None)
-                dataloader = getattr(trainer, "train_loader", None) or getattr(trainer, "train_dataloader", None) or getattr(trainer, "val_loader", None) or getattr(trainer, "val_dataloader", None)
-            except Exception:  # pragma: no cover - best effort
-                dataloader = None
-        self.pruning_method.generate_pruning_mask(ratio, dataloader)
+        self.pruning_method.generate_pruning_mask(ratio)
 
     def apply_pruning(self, rebuild: bool = False) -> None:
         """Apply the previously generated pruning mask to the model.

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -224,7 +224,7 @@ class PruningPipeline2(BasePruningPipeline):
             len(groups),
         )
 
-    def generate_pruning_mask(self, ratio: float, dataloader=None) -> None:
+    def generate_pruning_mask(self, ratio: float) -> None:
         if not isinstance(self.pruning_method, DepgraphHSICMethod):
             raise NotImplementedError
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
@@ -237,13 +237,7 @@ class PruningPipeline2(BasePruningPipeline):
                 self._run_short_forward_pass()
                 if not getattr(self.pruning_method, "activations", None) or not getattr(self.pruning_method, "labels", None):
                     self.logger.warning("Short forward pass did not record activations/labels")
-        if dataloader is None:
-            try:
-                trainer = getattr(self.model, "trainer", None)
-                dataloader = getattr(trainer, "train_loader", None) or getattr(trainer, "train_dataloader", None) or getattr(trainer, "val_loader", None) or getattr(trainer, "val_dataloader", None)
-            except Exception:  # pragma: no cover - best effort
-                dataloader = None
-        self.pruning_method.generate_pruning_mask(ratio, dataloader)
+        self.pruning_method.generate_pruning_mask(ratio)
         plan = getattr(self.pruning_method, "pruning_plan", {})
         if isinstance(plan, list):
             channels = len(plan)

--- a/pipeline/step/generate_masks.py
+++ b/pipeline/step/generate_masks.py
@@ -7,9 +7,8 @@ from . import PipelineStep
 class GenerateMasksStep(PipelineStep):
     """Generate pruning masks at a given sparsity ratio."""
 
-    def __init__(self, ratio: float, dataloader=None) -> None:
+    def __init__(self, ratio: float) -> None:
         self.ratio = ratio
-        self.dataloader = dataloader
 
     def run(self, context: PipelineContext) -> None:
         step = self.__class__.__name__
@@ -17,7 +16,7 @@ class GenerateMasksStep(PipelineStep):
         if context.pruning_method is None:
             raise NotImplementedError
         context.logger.info("Generating pruning mask at ratio %.2f", self.ratio)
-        context.pruning_method.generate_pruning_mask(self.ratio, self.dataloader)
+        context.pruning_method.generate_pruning_mask(self.ratio)
         context.logger.info("Finished %s", step)
 
 __all__ = ["GenerateMasksStep"]

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -287,7 +287,7 @@ class DepgraphHSICMethod(BasePruningMethod):
             self.labels,
         ) = saved
 
-    def generate_pruning_mask(self, ratio: float, dataloader=None) -> None:
+    def generate_pruning_mask(self, ratio: float) -> None:
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
         if not self.activations or not self.labels:
             self.logger.debug(

--- a/tests/test_apply_pruning_after_pipeline_steps.py
+++ b/tests/test_apply_pruning_after_pipeline_steps.py
@@ -97,7 +97,7 @@ def analyze_stub(self):
     self.layers = [self.model[0]]
     self.layer_names = ['0']
 method.analyze_model = types.MethodType(analyze_stub, method)
-def mask_stub(self, ratio, dataloader=None):
+def mask_stub(self, ratio):
     conv = self.layers[0]
     self.pruning_plan = [self.DG.get_pruning_group(conv, None, [0])]
 method.generate_pruning_mask = types.MethodType(mask_stub, method)

--- a/tests/test_baseline_skip_pipeline.py
+++ b/tests/test_baseline_skip_pipeline.py
@@ -96,7 +96,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             DummyMethod.calls = []
         def analyze_model(self):
             DummyMethod.calls.append('analyze')
-        def generate_pruning_mask(self, ratio, dataloader=None):
+        def generate_pruning_mask(self, ratio):
             DummyMethod.calls.append('mask')
         def apply_pruning(self):
             DummyMethod.calls.append('apply')
@@ -127,7 +127,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             DummyMethod.calls.append('pipeline_analyze')
         def set_pruning_method(self, method):
             self.pruning_method = method
-        def generate_pruning_mask(self, ratio, dataloader=None):
+        def generate_pruning_mask(self, ratio):
             pass
         def apply_pruning(self):
             pass

--- a/tests/test_execute_pipeline_device.py
+++ b/tests/test_execute_pipeline_device.py
@@ -64,7 +64,7 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
             pass
         def set_pruning_method(self, method):
             self.pruning_method = method
-        def generate_pruning_mask(self, ratio, dataloader=None):
+        def generate_pruning_mask(self, ratio):
             pass
         def apply_pruning(self):
             pass
@@ -88,7 +88,7 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
             self.model = model
         def analyze_model(self):
             pass
-        def generate_pruning_mask(self, ratio, dataloader=None):
+        def generate_pruning_mask(self, ratio):
             pass
         def apply_pruning(self):
             pass

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -38,7 +38,7 @@ def test_log_file_created_with_logger(tmp_path, monkeypatch):
         def analyze_structure(self):
             pass
 
-        def generate_pruning_mask(self, ratio, dataloader=None):
+        def generate_pruning_mask(self, ratio):
             pass
 
         def apply_pruning(self):

--- a/tests/test_pipeline_loader.py
+++ b/tests/test_pipeline_loader.py
@@ -47,12 +47,12 @@ def test_loader_passed(monkeypatch):
             super().__init__(model)
         def analyze_model(self):
             pass
-        def generate_pruning_mask(self, ratio, dataloader=None):
-            calls.append(dataloader)
+        def generate_pruning_mask(self, ratio):
+            calls.append(ratio)
         def apply_pruning(self):
             pass
 
     pipeline = pp.PruningPipeline2('m', 'd', pruning_method=DummyMethod(None))
     pipeline.load_model()
     pipeline.generate_pruning_mask(0.5)
-    assert calls == [loader]
+    assert calls == [0.5]

--- a/tests/test_reuse_baseline.py
+++ b/tests/test_reuse_baseline.py
@@ -38,7 +38,7 @@ class DummyPipeline:
         pass
     def analyze_structure(self):
         pass
-    def generate_pruning_mask(self, ratio, dataloader=None):
+    def generate_pruning_mask(self, ratio):
         pass
     def apply_pruning(self):
         pass

--- a/tests/test_snapshot_save.py
+++ b/tests/test_snapshot_save.py
@@ -29,7 +29,7 @@ class DummyPipeline:
         pass
     def set_pruning_method(self, method):
         self.pruning_method = method
-    def generate_pruning_mask(self, ratio, dataloader=None):
+    def generate_pruning_mask(self, ratio):
         pass
     def apply_pruning(self):
         pass

--- a/tests/test_train_step_auto_analyze.py
+++ b/tests/test_train_step_auto_analyze.py
@@ -99,7 +99,7 @@ def analyze_stub(self):
     self.layers = [self.model[0]]
     self.layer_names = ['0']
 method.analyze_model = types.MethodType(analyze_stub, method)
-def mask_stub(self, ratio, dataloader=None):
+def mask_stub(self, ratio):
     conv = self.layers[0]
     self.pruning_plan = [self.DG.get_pruning_group(conv, None, [0])]
 method.generate_pruning_mask = types.MethodType(mask_stub, method)


### PR DESCRIPTION
## Summary
- drop `dataloader` from `DepgraphHSICMethod.generate_pruning_mask`
- simplify pipeline mask generation functions
- adjust GenerateMasksStep API
- update README example
- update tests to new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685706ec274c83249a0cec8d7e8f2a6d