### PR TITLE
Add dataloader-based activation collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,14 @@ Example usage:
 method.generate_pruning_mask(0.5)
 method.apply_pruning()
 ```
+
+When calling ``generate_pruning_mask`` you may optionally provide a
+``DataLoader``. The method will perform a short inference run over the
+dataloader, recording activations through its registered hooks and storing the
+labels via :func:`add_labels`.  This can be useful when pruning without running
+the training pipeline:
+
+```python
+method.analyze_model()
+method.generate_pruning_mask(0.5, dataloader=loader)
+```


### PR DESCRIPTION
## Summary
- extend HSIC pruning to optionally collect activations from a dataloader
- fall back to L1-norm pruning when no activations are available
- guarantee at least one channel per layer is kept
- update README with dataloader instructions

## Testing
- `pytest tests/test_hsic_analyze_retry.py::test_final_retry_after_analyze -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68571eff14bc8324ab9376856ab9dac3