### PR TITLE
Add dataloader support for pruning mask generation

### DIFF
--- a/pipeline/base_pipeline.py
+++ b/pipeline/base_pipeline.py
@@ -58,8 +58,8 @@ class BasePruningPipeline(abc.ABC):
         """Analyze model structure to guide pruning decisions."""
 
     @abc.abstractmethod
-    def generate_pruning_mask(self, ratio: float) -> None:
-        """Create a pruning mask with the given sparsity ``ratio``."""
+    def generate_pruning_mask(self, ratio: float, dataloader: Any | None = None) -> None:
+        """Create a pruning mask with the given sparsity ``ratio`` using ``dataloader`` if provided."""
 
     @abc.abstractmethod
     def apply_pruning(self) -> None:

--- a/pipeline/context.py
+++ b/pipeline/context.py
@@ -18,6 +18,7 @@ class PipelineContext:
     pruning_method: Optional[BasePruningMethod] = None
     logger: Logger = field(default_factory=get_logger)
     model: Any = None
+    dataloader: Any = None
     initial_stats: Dict[str, float] = field(default_factory=dict)
     pruned_stats: Dict[str, float] = field(default_factory=dict)
     metrics: Dict[str, Any] = field(default_factory=dict)

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -203,12 +203,12 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Analyzing model structure")
         self.pruning_method.analyze_model()
 
-    def generate_pruning_mask(self, ratio: float) -> None:
-        """Generate pruning mask at ``ratio`` sparsity."""
+    def generate_pruning_mask(self, ratio: float, dataloader: Any | None = None) -> None:
+        """Generate pruning mask at ``ratio`` sparsity using ``dataloader`` if provided."""
         if self.pruning_method is None:
             raise NotImplementedError
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
-        self.pruning_method.generate_pruning_mask(ratio)
+        self.pruning_method.generate_pruning_mask(ratio, dataloader=dataloader)
 
     def apply_pruning(self, rebuild: bool = False) -> None:
         """Apply the previously generated pruning mask to the model.

--- a/pipeline/step/generate_masks.py
+++ b/pipeline/step/generate_masks.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from ..context import PipelineContext
 from . import PipelineStep
+from typing import Any
 
 
 class GenerateMasksStep(PipelineStep):
     """Generate pruning masks at a given sparsity ratio."""
 
-    def __init__(self, ratio: float) -> None:
+    def __init__(self, ratio: float, dataloader: Any | None = None) -> None:
         self.ratio = ratio
+        self.dataloader = dataloader
 
     def run(self, context: PipelineContext) -> None:
         step = self.__class__.__name__
@@ -16,7 +18,8 @@ class GenerateMasksStep(PipelineStep):
         if context.pruning_method is None:
             raise NotImplementedError
         context.logger.info("Generating pruning mask at ratio %.2f", self.ratio)
-        context.pruning_method.generate_pruning_mask(self.ratio)
+        dataloader = self.dataloader or getattr(context, "dataloader", None)
+        context.pruning_method.generate_pruning_mask(self.ratio, dataloader=dataloader)
         context.logger.info("Finished %s", step)
 
 __all__ = ["GenerateMasksStep"]

--- a/tests/test_apply_pruning_after_pipeline_steps.py
+++ b/tests/test_apply_pruning_after_pipeline_steps.py
@@ -97,7 +97,7 @@ def analyze_stub(self):
     self.layers = [self.model[0]]
     self.layer_names = ['0']
 method.analyze_model = types.MethodType(analyze_stub, method)
-def mask_stub(self, ratio):
+def mask_stub(self, ratio, dataloader=None):
     conv = self.layers[0]
     self.pruning_plan = [self.DG.get_pruning_group(conv, None, [0])]
 method.generate_pruning_mask = types.MethodType(mask_stub, method)

--- a/tests/test_baseline_skip_pipeline.py
+++ b/tests/test_baseline_skip_pipeline.py
@@ -96,7 +96,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             DummyMethod.calls = []
         def analyze_model(self):
             DummyMethod.calls.append('analyze')
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             DummyMethod.calls.append('mask')
         def apply_pruning(self):
             DummyMethod.calls.append('apply')
@@ -127,7 +127,7 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
             DummyMethod.calls.append('pipeline_analyze')
         def set_pruning_method(self, method):
             self.pruning_method = method
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
         def apply_pruning(self):
             pass

--- a/tests/test_execute_pipeline_device.py
+++ b/tests/test_execute_pipeline_device.py
@@ -64,7 +64,7 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
             pass
         def set_pruning_method(self, method):
             self.pruning_method = method
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
         def apply_pruning(self):
             pass
@@ -88,7 +88,7 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
             self.model = model
         def analyze_model(self):
             pass
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
         def apply_pruning(self):
             pass

--- a/tests/test_generate_masks_step_loader.py
+++ b/tests/test_generate_masks_step_loader.py
@@ -1,0 +1,21 @@
+from pipeline.context import PipelineContext
+from pipeline.step.generate_masks import GenerateMasksStep
+
+
+def test_generate_masks_step_uses_context_loader(tmp_path):
+    loader = object()
+
+    calls = []
+
+    class DummyMethod:
+        def generate_pruning_mask(self, ratio, dataloader=None):
+            calls.append(dataloader)
+
+    ctx = PipelineContext('m', 'd', workdir=tmp_path)
+    ctx.pruning_method = DummyMethod()
+    ctx.dataloader = loader
+
+    step = GenerateMasksStep(ratio=0.5)
+    step.run(ctx)
+
+    assert calls == [loader]

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -38,7 +38,7 @@ def test_log_file_created_with_logger(tmp_path, monkeypatch):
         def analyze_structure(self):
             pass
 
-        def generate_pruning_mask(self, ratio):
+        def generate_pruning_mask(self, ratio, dataloader=None):
             pass
 
         def apply_pruning(self):

--- a/tests/test_pipeline2_generate_mask_loader.py
+++ b/tests/test_pipeline2_generate_mask_loader.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import types
+
+
+def test_pipeline2_generate_mask_with_loader(monkeypatch):
+    loader = object()
+
+    up = types.ModuleType('ultralytics')
+    utils = types.ModuleType('ultralytics.utils')
+    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+    torch_utils.get_flops = lambda *a, **k: 0
+    torch_utils.get_num_params = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
+    up.utils = utils
+    up.YOLO = lambda *a, **k: types.SimpleNamespace(
+        model=types.SimpleNamespace(),
+        callbacks={},
+        trainer=types.SimpleNamespace(val_loader=loader),
+    )
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
+
+    hsic_mod = types.ModuleType('prune_methods.depgraph_hsic')
+
+    class DummyMethod:
+        def __init__(self, model=None, **kw):
+            self.model = model
+            self.calls = []
+
+        def analyze_model(self):
+            pass
+
+        def generate_pruning_mask(self, ratio, dataloader=None):
+            self.calls.append(dataloader)
+
+    hsic_mod.DepgraphHSICMethod = DummyMethod
+    monkeypatch.setitem(sys.modules, 'prune_methods.depgraph_hsic', hsic_mod)
+
+    pp = importlib.import_module('pipeline.pruning_pipeline_2')
+    importlib.reload(pp)
+
+    pipeline = pp.PruningPipeline2('m', 'd', pruning_method=DummyMethod(None))
+    pipeline.load_model()
+    pipeline._run_short_forward_pass = lambda: (_ for _ in ()).throw(RuntimeError('called'))
+    pipeline.generate_pruning_mask(0.5, dataloader=loader)
+    assert pipeline.pruning_method.calls == [loader]

--- a/tests/test_pipeline_loader.py
+++ b/tests/test_pipeline_loader.py
@@ -47,12 +47,12 @@ def test_loader_passed(monkeypatch):
             super().__init__(model)
         def analyze_model(self):
             pass
-        def generate_pruning_mask(self, ratio):
-            calls.append(ratio)
+        def generate_pruning_mask(self, ratio, dataloader=None):
+            calls.append(dataloader)
         def apply_pruning(self):
             pass
 
     pipeline = pp.PruningPipeline2('m', 'd', pruning_method=DummyMethod(None))
     pipeline.load_model()
     pipeline.generate_pruning_mask(0.5)
-    assert calls == [0.5]
+    assert calls == [loader]

--- a/tests/test_reuse_baseline.py
+++ b/tests/test_reuse_baseline.py
@@ -38,7 +38,7 @@ class DummyPipeline:
         pass
     def analyze_structure(self):
         pass
-    def generate_pruning_mask(self, ratio):
+    def generate_pruning_mask(self, ratio, dataloader=None):
         pass
     def apply_pruning(self):
         pass

--- a/tests/test_snapshot_save.py
+++ b/tests/test_snapshot_save.py
@@ -29,7 +29,7 @@ class DummyPipeline:
         pass
     def set_pruning_method(self, method):
         self.pruning_method = method
-    def generate_pruning_mask(self, ratio):
+    def generate_pruning_mask(self, ratio, dataloader=None):
         pass
     def apply_pruning(self):
         pass

--- a/tests/test_train_step_auto_analyze.py
+++ b/tests/test_train_step_auto_analyze.py
@@ -99,7 +99,7 @@ def analyze_stub(self):
     self.layers = [self.model[0]]
     self.layer_names = ['0']
 method.analyze_model = types.MethodType(analyze_stub, method)
-def mask_stub(self, ratio):
+def mask_stub(self, ratio, dataloader=None):
     conv = self.layers[0]
     self.pruning_plan = [self.DG.get_pruning_group(conv, None, [0])]
 method.generate_pruning_mask = types.MethodType(mask_stub, method)


### PR DESCRIPTION
## Summary
- extend `PipelineContext` with a `dataloader` attribute
- allow `GenerateMasksStep` to forward a dataloader
- update pruning pipelines to accept an optional dataloader
- adjust tests for new signatures and add new dataloader tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857240f943883248dc7235fcaaacea2