### PR TITLE
Improve short forward pass

### DIFF
--- a/pipeline/step/short_forward_pass.py
+++ b/pipeline/step/short_forward_pass.py
@@ -7,7 +7,7 @@ from . import PipelineStep
 
 
 class ShortForwardPassStep(PipelineStep):
-    """Run a single forward pass on the first validation image."""
+    """Run short forward passes on a couple of validation images."""
 
     def run(self, context: PipelineContext) -> None:  # pragma: no cover - heavy deps
         step = self.__class__.__name__
@@ -31,53 +31,67 @@ class ShortForwardPassStep(PipelineStep):
         base = Path(ds_cfg.get("path", Path(context.data).parent))
         val = ds_cfg.get("val") or ds_cfg.get("train")
         val_path = base / val if val is not None else base
+
+        imgs: list[Path] = []
         if val_path.is_dir():
-            imgs = sorted(val_path.glob("*.*"))
-            img = imgs[0] if imgs else None
-        else:
-            img = val_path if val_path.exists() else None
-        if img is None:
+            imgs = sorted(p for p in val_path.glob("*.*") if p.is_file())
+        elif val_path.exists():
+            imgs = [val_path]
+
+        if not imgs:
             context.logger.warning("no validation image found for short forward pass")
             context.logger.info("Finished %s", step)
             return
 
-        context.logger.info("short forward pass image: %s", img)
-        label_file = Path(str(img)).with_suffix(".txt").as_posix()
-        label_file = label_file.replace("/images/", "/labels/")
-        context.logger.info("short forward pass label file: %s", label_file)
-        y = torch.tensor([])
-        lf = Path(label_file)
-        if lf.exists():
-            with lf.open() as f:
-                labels = [float(line.split()[0]) for line in f if line.strip()]
-            if labels:
-                y = torch.tensor([labels[0]])
-                context.logger.info("label file %s has %d entries", label_file, len(labels))
-            else:
-                context.logger.warning("label file %s is empty", label_file)
-        else:
-            context.logger.warning("label file %s does not exist", label_file)
+        imgs = imgs[:2]
+        try:
+            context.pruning_method.register_hooks()
+        except Exception:
+            pass
 
-        if y.numel() > 0:
-            try:
-                img_pil = Image.open(img).convert("RGB")
-                orig_size = img_pil.size
-                if orig_size != (640, 640):
-                    context.logger.debug(
-                        "resizing short forward pass image from %s to (640, 640)",
-                        orig_size,
+        device = next(context.model.model.parameters()).device
+
+        for img in imgs:
+            context.logger.info("short forward pass image: %s", img)
+            label_file = Path(str(img)).with_suffix(".txt").as_posix()
+            label_file = label_file.replace("/images/", "/labels/")
+            context.logger.info("short forward pass label file: %s", label_file)
+            y = torch.tensor([])
+            lf = Path(label_file)
+            if lf.exists():
+                with lf.open() as f:
+                    labels = [float(line.split()[0]) for line in f if line.strip()]
+                if labels:
+                    y = torch.tensor([labels[0]])
+                    context.logger.info("label file %s has %d entries", label_file, len(labels))
+                else:
+                    context.logger.warning("label file %s is empty", label_file)
+            else:
+                context.logger.warning("label file %s does not exist", label_file)
+
+            if y.numel() > 0:
+                try:
+                    img_pil = Image.open(img).convert("RGB")
+                    orig_size = img_pil.size
+                    if orig_size != (640, 640):
+                        context.logger.debug(
+                            "resizing short forward pass image from %s to (640, 640)",
+                            orig_size,
+                        )
+                        img_pil = img_pil.resize((640, 640))
+                    arr = np.array(img_pil, dtype=np.float32)
+                    arr = np.transpose(arr, (2, 0, 1))
+                    inp = torch.tensor(arr).unsqueeze(0)
+                    context.logger.debug("short forward pass tensor shape: %s", tuple(inp.shape))
+                except Exception:  # pragma: no cover - fallback
+                    inp = getattr(
+                        context.pruning_method,
+                        "example_inputs",
+                        torch.randn(1, 3, 640, 640),
                     )
-                    img_pil = img_pil.resize((640, 640))
-                arr = np.array(img_pil, dtype=np.float32)
-                arr = np.transpose(arr, (2, 0, 1))
-                inp = torch.tensor(arr).unsqueeze(0)
-                context.logger.debug("short forward pass tensor shape: %s", tuple(inp.shape))
-            except Exception:  # pragma: no cover - fallback
-                inp = getattr(context.pruning_method, "example_inputs", torch.randn(1, 3, 640, 640))
-            device = next(context.model.model.parameters()).device
-            with torch.no_grad():
-                context.model.model(inp.to(device))
-            context.pruning_method.add_labels(y)
+                with torch.no_grad():
+                    context.model.model(inp.to(device))
+                context.pruning_method.add_labels(y)
         context.logger.info("Finished %s", step)
 
 

--- a/tests/test_generate_mask_no_baseline.py
+++ b/tests/test_generate_mask_no_baseline.py
@@ -74,9 +74,11 @@ sys.modules['yaml'] = yaml_mod
 
 tmp = Path("{tmp_path}")
 (tmp / 'images').mkdir()
-(tmp / 'images' / 'img.jpg').write_text('x')
+for i in range(2):
+    (tmp / 'images' / f'img{{i}}.jpg').write_text('x')
 (tmp / 'labels').mkdir()
-(tmp / 'labels' / 'img.txt').write_text('0')
+for i in range(2):
+    (tmp / 'labels' / f'img{{i}}.txt').write_text('0')
 data_file = tmp / 'd.yaml'
 data_file.write_text('path: .\\nval: images')
 


### PR DESCRIPTION
## Summary
- extend short forward pass to run on two images
- re-register hooks and accumulate labels for each
- update dataset in generate_mask_no_baseline test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68572a0507488324bb17f5b34f7a5234