### PR TITLE
Warn when HSIC lacks labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ the training pipeline:
 method.analyze_model()
 method.generate_pruning_mask(0.5, dataloader=loader)
 ```
+
+HSIC pruning relies on comparing activations across multiple label batches.
+If fewer than two label batches are recorded, the method issues a warning
+and falls back to L1-norm importance as HSIC scores cannot be computed
+reliably.

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -391,12 +391,21 @@ class DepgraphHSICMethod(BasePruningMethod):
             return
         label_batches = len(self.labels)
         self.logger.info("Recorded %d label batches", label_batches)
+        mismatch = False
         for idx, count in self.num_activations.items():
             self.logger.info("Layer %d recorded %d activations", idx, count)
             if count != label_batches:
+                mismatch = True
                 self.logger.warning(
                     "Layer %d has %d activations but %d labels", idx, count, label_batches
                 )
+        if label_batches < 2 and not mismatch:
+            self.logger.warning(
+                "Fewer than two label batches recorded; HSIC computation may be invalid"
+            )
+            self.logger.warning("Falling back to L1-norm importance")
+            self._l1_norm_plan(ratio)
+            return
         features = {}
         for idx, feats in self.activations.items():
             try:

--- a/tests/test_hsic_few_label_warning.py
+++ b/tests/test_hsic_few_label_warning.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_warning_for_few_labels(tmp_path):
+    code = f"""
+import logging
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+
+logging.basicConfig(level=logging.WARNING)
+
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.example_inputs = torch.randn(1, 3, 8, 8)
+method.analyze_model()
+model(torch.randn(1, 3, 8, 8))
+method.add_labels(torch.tensor([1.0]))
+method.generate_pruning_mask(0.5)
+"""
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    output = proc.stderr + proc.stdout
+    assert "HSIC computation may be invalid" in output
+    assert "L1-norm" in output
+


### PR DESCRIPTION
## Summary
- warn if fewer than two label batches have been collected before HSIC pruning
- document label requirement for HSIC pruning
- add regression test for the warning

## Testing
- `pytest tests/test_hsic_few_label_warning.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68572a1c47148324b2b609855984ade8