### PR TITLE
Extend pipeline2 to generic DepGraph methods

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from .base_pipeline import BasePruningPipeline
 from prune_methods.depgraph_hsic import DepgraphHSICMethod
+from prune_methods.base import BasePruningMethod
 from helper import (
     Logger,
     MetricManager,
@@ -19,14 +20,20 @@ from helper import (
 
 
 class PruningPipeline2(BasePruningPipeline):
-    """Simple pipeline specialised for :class:`DepgraphHSICMethod`."""
+    """Simple pipeline specialised for DepGraph pruning methods.
+
+    The pipeline works with any :class:`BasePruningMethod` that relies on the
+    ``torch-pruning`` dependency graph.  Additional HSIC specific logic is only
+    executed when the pruning method is an instance of
+    :class:`DepgraphHSICMethod`.
+    """
 
     def __init__(
         self,
         model_path: str,
         data: str,
         workdir: str = "runs/pruning",
-        pruning_method: DepgraphHSICMethod | None = None,
+        pruning_method: BasePruningMethod | None = None,
         logger: Logger | None = None,
     ) -> None:
         super().__init__(model_path, data, workdir, pruning_method, logger)
@@ -193,8 +200,8 @@ class PruningPipeline2(BasePruningPipeline):
         return metrics or {}
 
     def analyze_structure(self) -> None:
-        if not isinstance(self.pruning_method, DepgraphHSICMethod):
-            raise NotImplementedError("PruningPipeline2 requires DepgraphHSICMethod")
+        if self.pruning_method is None:
+            raise ValueError("No pruning method set")
         self.logger.info("Analyzing model structure")
         self._sync_pruning_method(reanalyze=True)
         groups = []
@@ -219,21 +226,28 @@ class PruningPipeline2(BasePruningPipeline):
         ratio: float,
         dataloader: Any | None = None,
     ) -> None:
-        if not isinstance(self.pruning_method, DepgraphHSICMethod):
-            raise NotImplementedError
+        if self.pruning_method is None:
+            raise ValueError("No pruning method set")
         self.logger.info("Generating pruning mask at ratio %.2f", ratio)
-        if self.pruning_method is not None:
-            self.pruning_method.model = self.model.model
-            self.logger.info("Reanalyzing model before mask generation")
-            self.pruning_method.analyze_model()
-            if (
-                dataloader is None
-                and (not getattr(self.pruning_method, "activations", None) or not getattr(self.pruning_method, "labels", None))
-            ):
-                self.logger.info("No activations/labels found; collecting synthetic activations")
-                self._collect_synthetic_activations_for_hsic()
-                if not getattr(self.pruning_method, "activations", None) or not getattr(self.pruning_method, "labels", None):
-                    self.logger.warning("Synthetic activation collection did not record activations/labels")
+        self.pruning_method.model = self.model.model
+        self.logger.info("Reanalyzing model before mask generation")
+        self.pruning_method.analyze_model()
+        if (
+            isinstance(self.pruning_method, DepgraphHSICMethod)
+            and dataloader is None
+            and (
+                not getattr(self.pruning_method, "activations", None)
+                or not getattr(self.pruning_method, "labels", None)
+            )
+        ):
+            self.logger.info(
+                "No activations/labels found; collecting synthetic activations"
+            )
+            self._collect_synthetic_activations_for_hsic()
+            if not getattr(self.pruning_method, "activations", None) or not getattr(self.pruning_method, "labels", None):
+                self.logger.warning(
+                    "Synthetic activation collection did not record activations/labels"
+                )
         if dataloader is None:
             dataloader = getattr(getattr(self.model, "trainer", None), "val_loader", None)
         self.pruning_method.generate_pruning_mask(
@@ -255,11 +269,10 @@ class PruningPipeline2(BasePruningPipeline):
         )
 
     def apply_pruning(self, rebuild: bool = False) -> None:
-        if not isinstance(self.pruning_method, DepgraphHSICMethod):
-            raise NotImplementedError
+        if self.pruning_method is None:
+            raise ValueError("No pruning method set")
         self.logger.info("Applying pruning")
-        if self.pruning_method is not None:
-            self.pruning_method.apply_pruning(rebuild=rebuild)
+        self.pruning_method.apply_pruning(rebuild=rebuild)
 
     def reconfigure_model(self, output_path: str | Path | None = None) -> None:
         # DepGraph methods don't require reconfiguration


### PR DESCRIPTION
## Summary
- support any DepGraph pruning algorithm in `PruningPipeline2`
- update constructor to accept `BasePruningMethod`
- make analysis, mask generation and pruning applicable to all DepGraph methods

## Testing
- `pytest -q` *(fails: ImportError while importing tests/test_continue_mode.py)*

------
https://chatgpt.com/codex/tasks/task_b_6858b13149ac8324946665e4ee4af12b