### PR TITLE
Update pipeline selection for TorchRandomMethod

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ def create_pipeline(
         pm.DepgraphHSICMethod,
         pm.DepgraphMethod,
         pm.IsomorphicMethod,
+        pm.TorchRandomMethod,
     )
     
     if method_cls in depgraph_methods:


### PR DESCRIPTION
## Summary
- ensure TorchRandomMethod uses `PruningPipeline2`

## Testing
- `pytest tests/test_new_methods_import.py::test_new_methods_have_flag -q`
- `pytest tests/test_continue_mode.py::test_continue_skips_completed_run -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_b_6858b5aa85b88324990d8e9136c02c60