### PR TITLE
simplify comparison step

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,12 +18,8 @@ from typing import Iterable, List, Type
 import logging
 
 from helper import ExperimentManager, get_logger, Logger, add_file_handler
-from pipeline import (
-    BasePruningPipeline,
-    PruningPipeline,
-    PruningPipeline2,
-    MonitorComputationStep,
-)
+from pipeline import BasePruningPipeline, PruningPipeline, MonitorComputationStep
+import pipeline as pipeline_mod
 from ultralytics import YOLO
 import prune_methods as pm
 from prune_methods import BasePruningMethod
@@ -46,7 +42,7 @@ def create_pipeline(
     )
     
     if method_cls in depgraph_methods:
-        return PruningPipeline2(
+        return pipeline_mod.PruningPipeline2(
             model_path=model_path,
             data=data,
             workdir=workdir,

--- a/pipeline/context.py
+++ b/pipeline/context.py
@@ -16,6 +16,7 @@ class PipelineContext:
     data: str
     workdir: Path = Path("runs/pruning")
     pruning_method: Optional[BasePruningMethod] = None
+    pipeline: Any = None
     logger: Logger = field(default_factory=get_logger)
     model: Any = None
     dataloader: Any = None

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -52,6 +52,7 @@ class PruningPipeline(BasePruningPipeline):
             pruning_method=self.pruning_method,
             logger=self.logger,
         )
+        context.pipeline = self
         context.metrics_mgr = self.metrics_mgr
         for step in self.steps:
             step.run(context)

--- a/pipeline/step/compare.py
+++ b/pipeline/step/compare.py
@@ -10,18 +10,11 @@ class CompareModelsStep(PipelineStep):
     def run(self, context: PipelineContext) -> None:
         step = self.__class__.__name__
         context.logger.info("Starting %s", step)
-        if context.pruning_method is None:
-            return
-        context.logger.info("Visualizing pruning results")
-        
-        # Call visualize_comparison if available
-        if hasattr(context.pruning_method, 'visualize_comparison'):
-            context.pruning_method.visualize_comparison()
-        
-        # Call visualize_pruned_filters if available
-        if hasattr(context.pruning_method, 'visualize_pruned_filters'):
-            context.pruning_method.visualize_pruned_filters()
-            
+        pipeline = getattr(context, "pipeline", None)
+        if pipeline is not None:
+            pipeline.visualize_results()
+        else:
+            context.logger.debug("No pipeline attached; skipping visualization")
         context.logger.info("Finished %s", step)
 
 __all__ = ["CompareModelsStep"]


### PR DESCRIPTION
## Summary
- update main to lazy import `PruningPipeline2`
- expose the pipeline instance on `PipelineContext`
- ensure pruning pipelines attach themselves to the context
- reduce `CompareModelsStep` to use `pipeline.visualize_results()`

## Testing
- `pytest -q` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_b_6858b73b2d448324a4997679a820c077