### PR TITLE
Update CHANGELOG for DepGraph pipeline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 - **Pipeline Architecture**: 
   - `PruningPipeline` untuk metode non-DepGraph (menggunakan AdaptiveReconfigurator)
-  - `PruningPipeline2` untuk metode DepGraph (tidak memerlukan rekonfigurasi)
+  - `PruningPipeline2` untuk metode DepGraph (tidak memerlukan rekonfigurasi) dan kini mendukung semua metode berbasis DepGraph
 - **Activation Collection**: Mengganti `ShortForwardPassStep` dengan synthetic data collection
 - **Memory Efficiency**: Menghilangkan penggunaan dataloader untuk activation collection
 
@@ -26,10 +26,10 @@
 - `DepgraphHSICMethod`
 - `DepgraphMethod`
 - `IsomorphicMethod`
+- `TorchRandomMethod`
 
 ## Metode Pruning Non-DepGraph:
 - `L1NormMethod`
 - `RandomMethod`
-- `TorchRandomMethod`
 - `HSICLassoMethod`
-- `WeightedHybridMethod` 
+- `WeightedHybridMethod`


### PR DESCRIPTION
## Summary
- update DepGraph method list
- note that `PruningPipeline2` now covers all DepGraph-based methods

## Testing
- `pytest -q` *(fails: 16 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6858bb91d5388324a2851e209046844d