### PR TITLE
Add device-aware input helper for pruning

### DIFF
--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -158,3 +158,26 @@ class BasePruningMethod(abc.ABC):
         except Exception as exc:  # pragma: no cover - optional
             self.logger.warning("Failed to save pruning results: %s", exc)
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _inputs_tuple(self) -> tuple:
+        """Return ``example_inputs`` as a tuple on the model's device."""
+        inputs = self.example_inputs
+        if not isinstance(inputs, tuple):
+            if isinstance(inputs, list):
+                inputs = tuple(inputs)
+            else:
+                inputs = (inputs,)
+        try:
+            device = next(self.model.parameters()).device
+        except Exception:
+            device = torch.device("cpu")
+        moved = []
+        for t in inputs:
+            if torch.is_tensor(t):
+                moved.append(t.to(device))
+            else:
+                moved.append(t)
+        return tuple(moved)
+

--- a/tests/test_pipeline2_depgraph_random.py
+++ b/tests/test_pipeline2_depgraph_random.py
@@ -72,7 +72,6 @@ def test_pipeline2_depgraph_and_random_methods(monkeypatch):
     pp, DepgraphMethod, TorchRandomMethod = setup(monkeypatch)
 
     for Method in (DepgraphMethod, TorchRandomMethod):
-        monkeypatch.setattr(Method, '_inputs_tuple', lambda self: (self.example_inputs,), raising=False)
         method = Method(None)
         pipeline = pp.PruningPipeline2('m', 'd', pruning_method=method)
         pipeline.load_model()


### PR DESCRIPTION
## Summary
- implement `_inputs_tuple` helper in `BasePruningMethod`
- leverage helper in `DepgraphHSICMethod` and register hooks when analyzing
- clean up `test_pipeline2_depgraph_random` monkeypatching

## Testing
- `pytest tests/test_inputs_tuple.py tests/test_pipeline2_depgraph_random.py tests/test_pruner_effect.py -q`
- `pytest -q` *(fails: 22 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6858c2f907508324a2d6c5e5a84d7508