### PR TITLE
Add training summary logs and sync pruning method

### DIFF
--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -7,7 +7,7 @@ from .logger import (
     format_header,
     format_step,
 )
-from .metric_manager import MetricManager
+from .metric_manager import MetricManager, format_training_summary
 from .experiment_manager import ExperimentManager
 from .heatmap_visualizer import (
     plot_metric_heatmaps,
@@ -32,4 +32,5 @@ __all__ = [
     "log_stats_comparison",
     "format_header",
     "format_step",
+    "format_training_summary",
 ]

--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -19,6 +19,21 @@ TRAINING_METRIC_FIELDS = [
     "cls_loss",
 ]
 
+# ------------------------------------------------------------------
+# Helper functions
+# ------------------------------------------------------------------
+
+def format_training_summary(metrics: Dict[str, Any]) -> str:
+    """Return a concise comma separated summary from ``metrics``.
+
+    Only values corresponding to :data:`TRAINING_METRIC_FIELDS` (or their
+    Ultralytics equivalents) are included.  Unknown keys are ignored.
+    """
+
+    mgr = MetricManager()
+    mgr.record_training(metrics or {})
+    return ", ".join(f"{k}={mgr.training[k]}" for k in mgr.training)
+
 # Mapping of Ultralytics training output names to canonical fields
 ULTRALYTICS_FIELD_MAP = {
     "metrics/precision": "precision",


### PR DESCRIPTION
## Summary
- summarize training metrics with new `format_training_summary`
- expose `format_training_summary` in `helper.__init__`
- log training summaries in pruning pipelines
- keep pruning method model reference in sync during finetune

## Testing
- `pytest -q tests/test_pruning_method_preserve_records.py::test_records_preserved_when_model_unchanged tests/test_pruning_pipeline2_model_update.py::test_pruning_pipeline2_model_updated_after_training tests/test_logger_file.py::test_log_file_created_with_logger tests/test_snapshot_save.py::test_snapshot_and_pruned_model_saved tests/test_pretrain_callback_cleanup.py::test_pretrain_unregisters_callback_on_error tests/test_pruning_method_model_update.py::test_pruning_method_model_updated_after_training`

------
https://chatgpt.com/codex/tasks/task_b_6858f2dfeac0832491bd4edaf50eb116