### PR TITLE
Warn when flops reported as zero

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -87,6 +87,10 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Calculating initial statistics")
         params = get_num_params(self.model.model)
         flops = get_flops(self.model.model)
+        if flops == 0:
+            self.logger.warning(
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+            )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
         self.initial_stats = {
@@ -185,6 +189,10 @@ class PruningPipeline(BasePruningPipeline):
         self.logger.info("Calculating pruned statistics")
         params = get_num_params(self.model.model)
         flops = get_flops(self.model.model)
+        if flops == 0:
+            self.logger.warning(
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+            )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
         self.pruned_stats = {

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -111,6 +111,10 @@ class PruningPipeline2(BasePruningPipeline):
         self.logger.info("Calculating initial model statistics")
         params = get_num_params(self.model.model)
         flops = get_flops(self.model.model)
+        if flops == 0:
+            self.logger.warning(
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+            )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
         self.initial_stats = {
@@ -251,6 +255,10 @@ class PruningPipeline2(BasePruningPipeline):
         self.logger.info("Calculating pruned model statistics")
         params = get_num_params(self.model.model)
         flops = get_flops(self.model.model)
+        if flops == 0:
+            self.logger.warning(
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+            )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
         self.pruned_stats = {


### PR DESCRIPTION
## Summary
- notify when `get_flops` returns zero in pruning pipelines

## Testing
- `pytest -q` *(fails: Insufficient labels, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6858fb4fefe083248ecdf42b659f6f25