### PR TITLE
Improve logging for silent exceptions

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def aggregate_labels(batch):
             if result:
                 cls = torch.tensor(result, dtype=cls.dtype, device=cls.device).float()  # Convert to float for cdist compatibility
     except Exception:
-        pass
+        logger.exception("aggregate_labels failed")
 
     # Ensure cls is float for cdist compatibility
     if torch.is_tensor(cls):
@@ -190,7 +190,7 @@ def _adjust_resume(phase_dir: Path, epochs: int, resume: bool, logger: Logger) -
                     logger.info("training completed previously – starting a new run")
                     return False
         except Exception:
-            pass
+            logger.exception("error checking previous training status")
     return resume
 
 

--- a/pipeline/base_pipeline.py
+++ b/pipeline/base_pipeline.py
@@ -71,7 +71,7 @@ class BasePruningPipeline(abc.ABC):
                                 batch["img"].shape[0],
                             )
                     except Exception:
-                        pass
+                        self.logger.exception("label_fn validation failed")
                     self.logger.debug(
                         "Adding labels for batch with shape %s", tuple(getattr(labels, "shape", []))
                     )
@@ -84,7 +84,7 @@ class BasePruningPipeline(abc.ABC):
             if self._label_callback not in existing:
                 self.model.add_callback("on_train_batch_end", self._label_callback)
         except AttributeError:
-            pass
+            self.logger.exception("failed to register label callback")
 
     def _unregister_label_callback(self) -> None:
         """Remove the label recording callback if present."""
@@ -93,7 +93,7 @@ class BasePruningPipeline(abc.ABC):
             if self._label_callback in callbacks:
                 callbacks.remove(self._label_callback)
         except Exception:
-            pass
+            self.logger.exception("failed to unregister label callback")
         self._label_callback = None
 
     def _sync_pruning_method(self, reanalyze: bool = False) -> None:
@@ -123,7 +123,7 @@ class BasePruningPipeline(abc.ABC):
                 "Model device: %s, example_inputs device: %s", device, ex_device
             )
         except Exception:
-            pass
+            self.logger.exception("failed to sync example inputs device")
 
     def _collect_synthetic_activations(self, num_samples=4) -> int:
         """Collect activations using synthetic data for HSIC methods."""

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -148,7 +148,7 @@ class PruningPipeline(BasePruningPipeline):
                         self._sync_pruning_method(reanalyze=True)
                         self.logger.debug("reanalyzed pruning method model")
                 except Exception:  # pragma: no cover - best effort
-                    pass
+                    self.logger.exception("failed to reanalyze model")
         self.logger.debug(metrics)
         if metrics:
             self.logger.info("Training summary: %s", format_training_summary(metrics))
@@ -237,7 +237,7 @@ class PruningPipeline(BasePruningPipeline):
                         self._sync_pruning_method(reanalyze=True)
                         self.logger.debug("reanalyzed pruning method model")
                 except Exception:  # pragma: no cover - best effort
-                    pass
+                    self.logger.exception("failed to reanalyze model")
         self.logger.debug(metrics)
         if metrics:
             self.logger.info("Training summary: %s", format_training_summary(metrics))

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -161,7 +161,7 @@ class PruningPipeline2(BasePruningPipeline):
                 # Use synthetic data collection instead of short forward pass
                 self._collect_synthetic_activations_for_hsic()
             except Exception:
-                pass
+                self.logger.exception("failed to refresh pruning method")
 
         self.logger.info("Training finished; recorded %d label batches", num_labels)
         if metrics:
@@ -294,7 +294,7 @@ class PruningPipeline2(BasePruningPipeline):
             try:
                 self._sync_pruning_method(reanalyze=model_changed)
             except Exception:
-                pass
+                self.logger.exception("failed to sync pruning method")
         self.logger.debug(metrics)
         if metrics:
             self.logger.info("Training summary: %s", format_training_summary(metrics))

--- a/pipeline/step/apply_pruning.py
+++ b/pipeline/step/apply_pruning.py
@@ -20,6 +20,6 @@ class ApplyPruningStep(PipelineStep):
             context.logger.info("Saving snapshot to %s", snapshot)
             context.model.save(str(snapshot))
         except Exception:  # pragma: no cover - best effort
-            pass
+            context.logger.exception("failed to save snapshot")
 
 __all__ = ["ApplyPruningStep"]

--- a/pipeline/step/load_model.py
+++ b/pipeline/step/load_model.py
@@ -24,6 +24,6 @@ class LoadModelStep(PipelineStep):
                     "Assigned loaded model to pruning method %s", pm.__class__.__name__
                 )
             except Exception:  # pragma: no cover - best effort
-                pass
+                context.logger.exception("failed to assign model to pruning method")
 
 __all__ = ["LoadModelStep"]

--- a/pipeline/step/reconfigure.py
+++ b/pipeline/step/reconfigure.py
@@ -27,7 +27,7 @@ class ReconfigureModelStep(PipelineStep):
                 try:
                     pm.model = context.model.model
                 except Exception:  # pragma: no cover - best effort
-                    pass
+                    context.logger.exception("failed to assign model during reconfigure")
         context.logger.info("Reconfiguring model")
         self.reconfigurator.reconfigure_model(context.model, output_path=self.output_path)
 

--- a/pipeline/step/train.py
+++ b/pipeline/step/train.py
@@ -50,7 +50,7 @@ class TrainStep(PipelineStep):
                                 batch["img"].shape[0],
                             )
                     except Exception:  # pragma: no cover - if torch missing or labels malformed
-                        pass
+                        context.logger.exception("label collection failed")
                     context.logger.debug(
                         "Adding labels for batch with shape %s", tuple(labels.shape)
                     )
@@ -61,7 +61,7 @@ class TrainStep(PipelineStep):
                 if record_labels not in existing:
                     context.model.add_callback("on_train_batch_end", record_labels)
             except AttributeError:  # pragma: no cover - fallback for stubs
-                pass
+                context.logger.exception("failed to attach label callback")
 
         original_model = getattr(context.model, "model", None)
         metrics = context.model.train(data=context.data, **self.train_kwargs)
@@ -72,7 +72,7 @@ class TrainStep(PipelineStep):
                 pm.model = context.model.model
                 context.logger.debug("updated pruning method model reference")
             except Exception:  # pragma: no cover - best effort
-                pass
+                context.logger.exception("failed to update pruning method model")
             try:
                 if hasattr(pm, "refresh_dependency_graph"):
                     # Avoid clearing collected activations when the model instance changes
@@ -89,7 +89,7 @@ class TrainStep(PipelineStep):
                     pm.analyze_model()
                     context.logger.debug("reanalyzed pruning method model")
             except Exception:  # pragma: no cover - best effort
-                pass
+                context.logger.exception("failed to refresh pruning method")
         context.metrics_mgr.record_training(metrics or {})
         context.metrics[self.phase] = metrics or {}
 

--- a/prune_methods/isomorphic_pruning.py
+++ b/prune_methods/isomorphic_pruning.py
@@ -54,5 +54,5 @@ class IsomorphicMethod(BasePruningMethod):
                 try:
                     reparam.prune_finalize()
                 except Exception:
-                    pass
+                    self.logger.exception("reparam prune finalize failed")
 


### PR DESCRIPTION
## Summary
- log exceptions during label callback operations
- log errors when saving snapshots
- report prune finalization errors
- log exceptions in pipelines and training steps

## Testing
- `pytest -q` *(fails: 22 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6858fff2019c83248958320bccb70ccb