### PR TITLE
Record GPU memory percent

### DIFF
--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -49,6 +49,7 @@ COMPUTATION_METRIC_FIELDS = [
     "gpu_utilization",
     "gpu_memory_used_mb",
     "gpu_memory_total_mb",
+    "gpu_memory_percent",
     "ram_used_mb",
     "ram_total_mb",
     "ram_percent",

--- a/pipeline/step/monitor_computation.py
+++ b/pipeline/step/monitor_computation.py
@@ -47,6 +47,7 @@ class MonitorComputationStep(PipelineStep):
             "total_time": elapsed,
             "total_time_minutes": elapsed / 60.0,
             "gpu_utilization": gpu_summary.get("avg_utilization", 0.0),
+            "gpu_memory_percent": gpu_summary.get("avg_memory_percent", 0.0),
             "gpu_memory_used_mb": gpu_metrics.get("gpu_memory_used_mb", 0.0),
             "gpu_memory_total_mb": gpu_metrics.get("gpu_memory_total_mb", 0.0),
             "ram_used_mb": mem_metrics.get("ram_used_mb", 0.0),

--- a/tests/test_monitor_step.py
+++ b/tests/test_monitor_step.py
@@ -97,12 +97,14 @@ def test_monitor_metrics_recorded(monkeypatch, tmp_path):
     pipeline, _ = main.execute_pipeline('m.pt', 'd.yaml', None, 0, cfg, tmp_path)
     comp = pipeline.metrics_mgr.computation
     assert comp['gpu_utilization'] == 42
+    assert comp['gpu_memory_percent'] == 50
     assert comp['ram_percent'] == 30
     assert comp['avg_ram_used_mb'] == 3
     assert comp['power_usage_watts'] == 5
     metrics = pipeline.record_metrics()
     assert 'computation' in metrics
     assert metrics['computation']['gpu_utilization'] == 42
+    assert metrics['computation']['gpu_memory_percent'] == 50
     assert metrics['computation']['ram_percent'] == 30
     assert metrics['computation']['avg_ram_used_mb'] == 3
     assert metrics['computation']['power_usage_watts'] == 5


### PR DESCRIPTION
## Summary
- record `gpu_memory_percent` in computation metrics
- store GPU memory percent when monitoring computation
- test that GPU memory percent is returned from the monitor step

## Testing
- `python -m py_compile helper/metric_manager.py pipeline/step/monitor_computation.py tests/test_monitor_step.py`
- `pytest tests/test_monitor_step.py::test_monitor_metrics_recorded -q` *(fails: module 'torch.nn' has no attribute 'Module')*

------
https://chatgpt.com/codex/tasks/task_b_685906ab28248324b8ed41f8a891acde