### PR TITLE
Add layer subset stats utilities and metrics

### DIFF
--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -18,6 +18,9 @@ from .metrics_loader import load_metrics_dataframe
 from .model_stats import (
     count_filters,
     model_size_mb,
+    count_params_in_layers,
+    count_filters_in_layers,
+    flops_in_layers,
     file_size_mb,
     log_stats_comparison,
 )
@@ -34,6 +37,9 @@ __all__ = [
     "load_metrics_dataframe",
     "count_filters",
     "model_size_mb",
+    "count_params_in_layers",
+    "count_filters_in_layers",
+    "flops_in_layers",
     "file_size_mb",
     "log_stats_comparison",
     "format_header",

--- a/helper/logger.py
+++ b/helper/logger.py
@@ -45,6 +45,10 @@ class Logger:
     def error(self, msg: str, *args, **kwargs) -> None:
         self.logger.error(msg, *args, **kwargs)
 
+    def exception(self, msg: str, *args, **kwargs) -> None:
+        """Log ``msg`` with exception information."""
+        self.logger.exception(msg, *args, **kwargs)
+
     def debug(self, msg: str, *args, **kwargs) -> None:
         self.logger.debug(msg, *args, **kwargs)
 

--- a/helper/metric_manager.py
+++ b/helper/metric_manager.py
@@ -62,6 +62,12 @@ PRUNING_METRIC_FIELDS = {
     "flops": ["original", "pruned", "reduction", "reduction_percent"],
     "filters": ["original", "pruned", "reduction", "reduction_percent"],
     "model_size_mb": ["original", "pruned", "reduction", "reduction_percent"],
+    "parameters_backbone": ["original", "pruned", "reduction", "reduction_percent"],
+    "parameters_head": ["original", "pruned", "reduction", "reduction_percent"],
+    "flops_backbone": ["original", "pruned", "reduction", "reduction_percent"],
+    "flops_head": ["original", "pruned", "reduction", "reduction_percent"],
+    "filters_backbone": ["original", "pruned", "reduction", "reduction_percent"],
+    "filters_head": ["original", "pruned", "reduction", "reduction_percent"],
     "compression_ratio": None,
 }
 

--- a/tests/test_calc_stats_step.py
+++ b/tests/test_calc_stats_step.py
@@ -35,6 +35,15 @@ def test_calc_stats_records_filters_and_size(monkeypatch):
     monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 20, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 3, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 1.5, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_filters_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.flops_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_filters_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.flops_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_filters_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.flops_in_layers", lambda *a, **k: 0, raising=False)
 
     step = CalcStatsStep("initial")
     step.run(ctx)
@@ -72,6 +81,9 @@ def test_calc_stats_records_compression_ratio(monkeypatch):
     monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 20, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 3, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 1.5, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_filters_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.flops_in_layers", lambda *a, **k: 0, raising=False)
 
     CalcStatsStep("initial").run(ctx)
 
@@ -79,7 +91,48 @@ def test_calc_stats_records_compression_ratio(monkeypatch):
     monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 10, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 2, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 1.0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.count_filters_in_layers", lambda *a, **k: 0, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.flops_in_layers", lambda *a, **k: 0, raising=False)
 
     CalcStatsStep("pruned").run(ctx)
 
     assert ctx.metrics_mgr.pruning["compression_ratio"] == 2.0
+
+
+def test_calc_stats_split_metrics(monkeypatch):
+    import torch.nn as nn
+
+    monkeypatch.setitem(sys.modules, "ultralytics", types.ModuleType("ultralytics"))
+    utils = types.ModuleType("ultralytics.utils")
+    torch_utils = types.ModuleType("ultralytics.utils.torch_utils")
+    monkeypatch.setitem(sys.modules, "ultralytics.utils", utils)
+    monkeypatch.setitem(sys.modules, "ultralytics.utils.torch_utils", torch_utils)
+
+    torch_utils.get_flops = lambda m: sum(1 for mod in m.modules() if isinstance(mod, nn.Conv2d))
+    torch_utils.get_num_params = lambda m: sum(p.numel() for p in m.parameters())
+
+    from pipeline.step.calc_stats import CalcStatsStep
+    from pipeline.context import PipelineContext
+
+    class DummyYOLO:
+        def __init__(self, count):
+            self.model = nn.ModuleList([nn.Conv2d(1, 1, 1) for _ in range(count)])
+
+        def save(self, p):
+            pass
+
+    ctx = PipelineContext(model_path="m", data="d")
+    ctx.model = DummyYOLO(12)
+
+    monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 0, raising=False)
+    step = CalcStatsStep("initial")
+    step.run(ctx)
+
+    ctx.model = DummyYOLO(8)
+    CalcStatsStep("pruned").run(ctx)
+
+    assert ctx.metrics_mgr.pruning["parameters_backbone"]["original"] == 20
+    assert ctx.metrics_mgr.pruning["parameters_head"]["original"] == 4
+    assert ctx.metrics_mgr.pruning["parameters_backbone"]["reduction"] == 4
+    assert ctx.metrics_mgr.pruning["parameters_head"]["reduction"] == 4


### PR DESCRIPTION
## Summary
- add helper functions to compute parameter, filter and FLOP counts for a slice of layers
- extend `CalcStatsStep` to record backbone and head statistics
- expose new metrics in `MetricManager`
- update logger with an `exception` helper
- test calculation of split metrics

## Testing
- `pytest tests/test_calc_stats_step.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68590ebfb574832489270cda4bf8d69b