### PR TITLE
Add FLOPs utilities module

### DIFF
--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -24,6 +24,7 @@ from .model_stats import (
     file_size_mb,
     log_stats_comparison,
 )
+from .flops_utils import calculate_flops_manual, get_flops_reliable
 
 __all__ = [
     "Logger",
@@ -42,6 +43,8 @@ __all__ = [
     "flops_in_layers",
     "file_size_mb",
     "log_stats_comparison",
+    "calculate_flops_manual",
+    "get_flops_reliable",
     "format_header",
     "format_step",
     "format_training_summary",

--- a/helper/flops_utils.py
+++ b/helper/flops_utils.py
@@ -1,0 +1,84 @@
+"""Utility functions for FLOPs calculation with graceful fallbacks."""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+try:
+    import torch
+    import torch.nn as nn
+except Exception:  # pragma: no cover - torch may be missing
+    torch = None  # type: ignore
+    nn = None  # type: ignore
+
+try:
+    from ultralytics.utils.torch_utils import get_flops as _get_flops  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    _get_flops = None  # type: ignore
+
+
+def _conv_hook(module: Any, _inp: Iterable[Any], output: Any, totals: list[int]) -> None:
+    if torch is None or not hasattr(torch, "Tensor"):
+        return
+    Tensor = getattr(torch, "Tensor", None)
+    if Tensor is None or not isinstance(output, Tensor):
+        return
+    out_h, out_w = output.shape[-2:]
+    batch = output.shape[0]
+    kernel_ops = module.kernel_size[0] * module.kernel_size[1] * (module.in_channels / module.groups)
+    totals[0] += int(batch * module.out_channels * out_h * out_w * kernel_ops)
+
+
+def _linear_hook(module: Any, _inp: Iterable[Any], output: Any, totals: list[int]) -> None:
+    if torch is None or not hasattr(torch, "Tensor"):
+        return
+    Tensor = getattr(torch, "Tensor", None)
+    if Tensor is None or not isinstance(output, Tensor):
+        return
+    batch = output.shape[0] if output.dim() > 1 else 1
+    totals[0] += int(batch * module.in_features * module.out_features)
+
+
+def calculate_flops_manual(model: Any, imgsz: int | Iterable[int] = 640) -> float:
+    """Return FLOPs in billions using a simple forward hook approach."""
+    if torch is None or nn is None or not hasattr(torch, "zeros"):
+        return 0.0
+    if isinstance(imgsz, (int, float)):
+        shape = (1, 3, int(imgsz), int(imgsz))
+    else:
+        s = list(imgsz)
+        if len(s) == 2:
+            shape = (1, 3, s[0], s[1])
+        elif len(s) == 3:
+            shape = (1, s[0], s[1], s[2])
+        else:
+            shape = tuple(s)
+    dummy = torch.zeros(*shape)
+    totals = [0]
+    hooks = []
+    for module in model.modules():
+        if isinstance(module, nn.Conv2d):
+            hooks.append(module.register_forward_hook(lambda m, i, o, t=totals: _conv_hook(m, i, o, t)))
+        elif isinstance(module, nn.Linear):
+            hooks.append(module.register_forward_hook(lambda m, i, o, t=totals: _linear_hook(m, i, o, t)))
+    model.eval()
+    with torch.no_grad():
+        model(dummy)
+    for h in hooks:
+        h.remove()
+    return totals[0] * 2 / 1e9
+
+
+def get_flops_reliable(model: Any, imgsz: int | Iterable[int] = 640) -> float:
+    """Return FLOPs using ``ultralytics`` if available, else manual calculation."""
+    flops = 0.0
+    if _get_flops is not None:
+        try:
+            flops = float(_get_flops(model, imgsz=imgsz))
+        except Exception:  # pragma: no cover - best effort
+            flops = 0.0
+    if not flops:
+        flops = calculate_flops_manual(model, imgsz)
+    return flops
+
+
+__all__ = ["calculate_flops_manual", "get_flops_reliable"]

--- a/tests/test_flops_utils.py
+++ b/tests/test_flops_utils.py
@@ -1,0 +1,32 @@
+import importlib
+import types
+import sys
+
+
+def test_calculate_flops_manual_no_torch(monkeypatch):
+    torch_stub = types.ModuleType('torch')
+    torch_nn_stub = types.ModuleType('torch.nn')
+    monkeypatch.setitem(sys.modules, 'torch', torch_stub)
+    monkeypatch.setitem(sys.modules, 'torch.nn', torch_nn_stub)
+    fu = importlib.import_module('helper.flops_utils')
+    importlib.reload(fu)
+    assert fu.calculate_flops_manual(None) == 0.0
+
+
+def test_get_flops_reliable_fallback(monkeypatch):
+    import torch.nn as nn
+    model = nn.Sequential(nn.Conv2d(3, 8, 1))
+    up = types.ModuleType('ultralytics')
+    utils = types.ModuleType('ultralytics.utils')
+    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+    torch_utils.get_flops = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
+    up.utils = utils
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
+
+    fu = importlib.import_module('helper.flops_utils')
+    importlib.reload(fu)
+    flops = fu.get_flops_reliable(model, imgsz=8)
+    assert flops > 0


### PR DESCRIPTION
## Summary
- provide `calculate_flops_manual` and `get_flops_reliable` in new `flops_utils` module
- export FLOPs helpers via `helper.__init__`
- cover functionality with unit tests

## Testing
- `pytest -q tests/test_flops_utils.py`
- `pytest -q` *(fails: CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_b_685920283db48324a501d2a7fa9886eb