### PR TITLE
Use reliable flops & params utils

### DIFF
--- a/helper/__init__.py
+++ b/helper/__init__.py
@@ -24,7 +24,11 @@ from .model_stats import (
     file_size_mb,
     log_stats_comparison,
 )
-from .flops_utils import calculate_flops_manual, get_flops_reliable
+from .flops_utils import (
+    calculate_flops_manual,
+    get_flops_reliable,
+    get_num_params_reliable,
+)
 
 __all__ = [
     "Logger",
@@ -45,6 +49,7 @@ __all__ = [
     "log_stats_comparison",
     "calculate_flops_manual",
     "get_flops_reliable",
+    "get_num_params_reliable",
     "format_header",
     "format_step",
     "format_training_summary",

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -22,7 +22,7 @@ from .context import PipelineContext
 from .step import PipelineStep
 
 from ultralytics import YOLO
-from ultralytics.utils.torch_utils import get_flops, get_num_params
+from helper.flops_utils import get_flops_reliable, get_num_params_reliable
 
 
 class PruningPipeline(BasePruningPipeline):
@@ -85,11 +85,11 @@ class PruningPipeline(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Calculating initial statistics")
-        params = get_num_params(self.model.model)
-        flops = get_flops(self.model.model)
+        params = get_num_params_reliable(self.model.model)
+        flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
@@ -187,11 +187,11 @@ class PruningPipeline(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Calculating pruned statistics")
-        params = get_num_params(self.model.model)
-        flops = get_flops(self.model.model)
+        params = get_num_params_reliable(self.model.model)
+        flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from pathlib import Path
 
 from ultralytics import YOLO
-from ultralytics.utils.torch_utils import get_flops, get_num_params
+from helper.flops_utils import get_flops_reliable, get_num_params_reliable
 from torch import nn
 
 from .base_pipeline import BasePruningPipeline
@@ -109,11 +109,11 @@ class PruningPipeline2(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Calculating initial model statistics")
-        params = get_num_params(self.model.model)
-        flops = get_flops(self.model.model)
+        params = get_num_params_reliable(self.model.model)
+        flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
@@ -253,11 +253,11 @@ class PruningPipeline2(BasePruningPipeline):
         if self.model is None:
             raise ValueError("Model is not loaded")
         self.logger.info("Calculating pruned model statistics")
-        params = get_num_params(self.model.model)
-        flops = get_flops(self.model.model)
+        params = get_num_params_reliable(self.model.model)
+        flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed"
+                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)

--- a/pipeline/step/calc_stats.py
+++ b/pipeline/step/calc_stats.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ultralytics.utils.torch_utils import get_flops, get_num_params
+from helper.flops_utils import get_flops_reliable, get_num_params_reliable
 
 from pathlib import Path
 
@@ -27,8 +27,8 @@ class CalcStatsStep(PipelineStep):
         if context.model is None:
             raise ValueError("Model is not loaded")
         context.logger.info("Calculating %s statistics", self.dest)
-        params = get_num_params(context.model.model)
-        flops = get_flops(context.model.model)
+        params = get_num_params_reliable(context.model.model)
+        flops = get_flops_reliable(context.model.model)
         filters = count_filters(context.model.model)
 
         params_bb = count_params_in_layers(context.model, 0, 10)

--- a/tests/test_calc_stats_step.py
+++ b/tests/test_calc_stats_step.py
@@ -31,8 +31,8 @@ def test_calc_stats_records_filters_and_size(monkeypatch):
     ctx = PipelineContext(model_path="m", data="d")
     ctx.model = dummy_model
 
-    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params", lambda m: 10, raising=False)
-    monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 20, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params_reliable", lambda m: 10, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_flops_reliable", lambda m: 20, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 3, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 1.5, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
@@ -77,8 +77,8 @@ def test_calc_stats_records_compression_ratio(monkeypatch):
     ctx = PipelineContext(model_path="m", data="d")
     ctx.model = dummy_model
 
-    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params", lambda m: 10, raising=False)
-    monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 20, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params_reliable", lambda m: 10, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_flops_reliable", lambda m: 20, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 3, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 1.5, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)
@@ -87,8 +87,8 @@ def test_calc_stats_records_compression_ratio(monkeypatch):
 
     CalcStatsStep("initial").run(ctx)
 
-    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params", lambda m: 5, raising=False)
-    monkeypatch.setattr("pipeline.step.calc_stats.get_flops", lambda m: 10, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_num_params_reliable", lambda m: 5, raising=False)
+    monkeypatch.setattr("pipeline.step.calc_stats.get_flops_reliable", lambda m: 10, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_filters", lambda m: 2, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.file_size_mb", lambda p: 1.0, raising=False)
     monkeypatch.setattr("pipeline.step.calc_stats.count_params_in_layers", lambda *a, **k: 0, raising=False)

--- a/tests/test_flops_utils.py
+++ b/tests/test_flops_utils.py
@@ -30,3 +30,26 @@ def test_get_flops_reliable_fallback(monkeypatch):
     importlib.reload(fu)
     flops = fu.get_flops_reliable(model, imgsz=8)
     assert flops > 0
+
+
+def test_get_num_params_reliable_fallback(monkeypatch):
+    model = types.SimpleNamespace(
+        parameters=lambda: [
+            types.SimpleNamespace(numel=lambda: 4),
+            types.SimpleNamespace(numel=lambda: 6),
+        ]
+    )
+    up = types.ModuleType('ultralytics')
+    utils = types.ModuleType('ultralytics.utils')
+    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
+    torch_utils.get_num_params = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
+    up.utils = utils
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
+
+    fu = importlib.import_module('helper.flops_utils')
+    importlib.reload(fu)
+    params = fu.get_num_params_reliable(model)
+    assert params == 10

--- a/tests/test_initial_stats_reset.py
+++ b/tests/test_initial_stats_reset.py
@@ -32,8 +32,8 @@ sys.modules['prune_methods.depgraph_hsic'] = hsic_mod
 
 import pipeline.pruning_pipeline as pp
 
-pp.get_flops = torch_utils.get_flops
-pp.get_num_params = torch_utils.get_num_params
+pp.get_flops_reliable = lambda m: 0
+pp.get_num_params_reliable = lambda m: 0
 pp.count_filters = lambda m: 0
 pp.model_size_mb = lambda m: 0
 

--- a/tests/test_metrics_csv.py
+++ b/tests/test_metrics_csv.py
@@ -37,8 +37,13 @@ sys.modules['ultralytics.utils.torch_utils'] = torch_utils
 import main
 import pipeline.pruning_pipeline as pp
 pp.YOLO = up.YOLO
-pp.get_flops = torch_utils.get_flops
-pp.get_num_params = torch_utils.get_num_params
+pp.get_flops_reliable = torch_utils.get_flops
+pp.get_num_params_reliable = torch_utils.get_num_params
+hsic_mod = types.ModuleType('prune_methods.depgraph_hsic')
+class DummyMethod:  # pragma: no cover - placeholder
+    pass
+hsic_mod.DepgraphHSICMethod = DummyMethod
+sys.modules['prune_methods.depgraph_hsic'] = hsic_mod
 
 
 def test_metrics_csv_created(tmp_path):


### PR DESCRIPTION
## Summary
- update FLOP/parameter utilities with fallback
- replace direct ultralytics flops/params calls
- adjust CalcStatsStep and pipelines to use reliable functions
- add missing stubs in metrics test
- test new parameter utility

## Testing
- `pytest tests/test_flops_utils.py -q`
- `pytest tests/test_initial_stats_reset.py::test_calc_initial_stats_resets_records -q`
- `pytest tests/test_metrics_csv.py::test_metrics_csv_created -q`
- `pytest tests/test_calc_stats_step.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68592316b9408324bdf38275ed9f8d48