### PR TITLE
Use reliable flops util in model stats

### DIFF
--- a/helper/model_stats.py
+++ b/helper/model_stats.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import logging
 
+from .flops_utils import get_flops_reliable
+
 try:
     import torch.nn as nn  # type: ignore
 except Exception:  # pragma: no cover - torch may not be installed
@@ -68,18 +70,14 @@ def count_filters_in_layers(model: Any, start: int, end: int | None = None) -> i
 
 
 def flops_in_layers(model: Any, start: int, end: int | None = None) -> float:
-    """Return FLOPs for ``model.model[start:end]`` using ``get_flops``."""
-    try:
-        from ultralytics.utils.torch_utils import get_flops  # type: ignore
-    except Exception:  # pragma: no cover - optional dependency
-        return 0.0
+    """Return FLOPs for ``model.model[start:end]`` using ``get_flops_reliable``."""
     modules = list(getattr(model, "model", [])[start:end])
     if nn is not None and hasattr(nn, "Sequential"):
         container = nn.Sequential(*modules)
     else:
         from types import SimpleNamespace
         container = SimpleNamespace(model=modules)
-    return get_flops(container)
+    return float(get_flops_reliable(container))
 
 
 


### PR DESCRIPTION
## Summary
- compute FLOPs for layer ranges using `get_flops_reliable`

## Testing
- `pytest tests/test_flops_utils.py -q`
- `pytest -q` *(fails: AttributeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_685926112ec48324907f74755fce39b6