### PR TITLE
Remove optional THOP package from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,19 @@ pip install scikit-learn
 
 ### FLOP statistics
 
-FLOP counting relies on the optional `ultralytics-thop` package. If it is not
-installed, functions such as `get_flops` return `0`. The pruning pipeline then
-logs a warning:
+FLOP counting relies on the optional `ultralytics-thop` package, which is **not**
+included in `requirements.txt`. Without it, functions such as `get_flops`
+return ``0`` and the pruning pipeline logs a warning:
 
 ```
 FLOPs reported as 0; verify that 'ultralytics-thop' is installed
 ```
 
-Install `ultralytics-thop` to ensure accurate FLOP metrics.
+Install ``ultralytics-thop`` separately if you require accurate FLOP metrics:
+
+```bash
+pip install ultralytics-thop
+```
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ psutil
 py-cpuinfo
 pandas>=1.1.4
 scikit-learn>=1.4.0
-ultralytics-thop>=2.0.0
 ultralytics>=8.0.0
 seaborn>=0.12.0
 torch-pruning>=1.5.2


### PR DESCRIPTION
## Summary
- remove `ultralytics-thop` from runtime requirements
- update FLOP statistics section in README

## Testing
- `pytest tests/test_flops_utils.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_685927697eec832490168827a8189f00