### PR TITLE
Update tests to use flops_utils

### DIFF
--- a/tests/test_aggregate_labels.py
+++ b/tests/test_aggregate_labels.py
@@ -18,8 +18,9 @@ def _import_main(monkeypatch):
     up = types.ModuleType("ultralytics")
     utils = types.ModuleType("ultralytics.utils")
     torch_utils = types.ModuleType("ultralytics.utils.torch_utils")
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: None

--- a/tests/test_apply_pruning_after_pipeline_steps.py
+++ b/tests/test_apply_pruning_after_pipeline_steps.py
@@ -69,9 +69,10 @@ class DummyYOLO:
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda m: 0
 torch_utils.get_num_params = lambda m: 0
 utils.torch_utils = torch_utils
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda m: 0
 up.utils = utils
 up.YOLO = lambda *a, **k: DummyYOLO()
 sys.modules['ultralytics'] = up

--- a/tests/test_baseline_skip_pipeline.py
+++ b/tests/test_baseline_skip_pipeline.py
@@ -33,8 +33,9 @@ def test_pipeline_runs_without_baseline(monkeypatch, tmp_path):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
 
     class DummyModel:

--- a/tests/test_calc_stats_step.py
+++ b/tests/test_calc_stats_step.py
@@ -9,8 +9,9 @@ def test_calc_stats_records_filters_and_size(monkeypatch):
     monkeypatch.setitem(sys.modules, "ultralytics", types.ModuleType("ultralytics"))
     utils = types.ModuleType("ultralytics.utils")
     torch_utils = types.ModuleType("ultralytics.utils.torch_utils")
-    torch_utils.get_flops = lambda *a, **k: 20
     torch_utils.get_num_params = lambda *a, **k: 10
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 20, raising=False)
     monkeypatch.setitem(sys.modules, "ultralytics.utils", utils)
     monkeypatch.setitem(sys.modules, "ultralytics.utils.torch_utils", torch_utils)
 
@@ -56,8 +57,9 @@ def test_calc_stats_records_compression_ratio(monkeypatch):
     monkeypatch.setitem(sys.modules, "ultralytics", types.ModuleType("ultralytics"))
     utils = types.ModuleType("ultralytics.utils")
     torch_utils = types.ModuleType("ultralytics.utils.torch_utils")
-    torch_utils.get_flops = lambda *a, **k: 20
     torch_utils.get_num_params = lambda *a, **k: 10
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 20, raising=False)
     monkeypatch.setitem(sys.modules, "ultralytics.utils", utils)
     monkeypatch.setitem(sys.modules, "ultralytics.utils.torch_utils", torch_utils)
 
@@ -109,8 +111,14 @@ def test_calc_stats_split_metrics(monkeypatch):
     monkeypatch.setitem(sys.modules, "ultralytics.utils", utils)
     monkeypatch.setitem(sys.modules, "ultralytics.utils.torch_utils", torch_utils)
 
-    torch_utils.get_flops = lambda m: sum(1 for mod in m.modules() if isinstance(mod, nn.Conv2d))
     torch_utils.get_num_params = lambda m: sum(p.numel() for p in m.parameters())
+    from helper import flops_utils as fu
+    monkeypatch.setattr(
+        fu,
+        "get_flops_reliable",
+        lambda m: sum(1 for mod in m.modules() if isinstance(mod, nn.Conv2d)),
+        raising=False,
+    )
 
     from pipeline.step.calc_stats import CalcStatsStep
     from pipeline.context import PipelineContext

--- a/tests/test_continue_mode.py
+++ b/tests/test_continue_mode.py
@@ -11,9 +11,10 @@ sys.modules['torch.nn'] = types.ModuleType('torch.nn')
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
 utils.torch_utils = torch_utils
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 0
 up.utils = utils
 up.YOLO = lambda *a, **k: None
 sys.modules['ultralytics'] = up

--- a/tests/test_execute_pipeline_device.py
+++ b/tests/test_execute_pipeline_device.py
@@ -16,8 +16,9 @@ def test_execute_pipeline_moves_model_to_device(monkeypatch, tmp_path):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     sys.modules['ultralytics'] = up

--- a/tests/test_flops_utils.py
+++ b/tests/test_flops_utils.py
@@ -16,18 +16,9 @@ def test_calculate_flops_manual_no_torch(monkeypatch):
 def test_get_flops_reliable_fallback(monkeypatch):
     import torch.nn as nn
     model = nn.Sequential(nn.Conv2d(3, 8, 1))
-    up = types.ModuleType('ultralytics')
-    utils = types.ModuleType('ultralytics.utils')
-    torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
-    utils.torch_utils = torch_utils
-    up.utils = utils
-    monkeypatch.setitem(sys.modules, 'ultralytics', up)
-    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
-    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', torch_utils)
-
-    fu = importlib.import_module('helper.flops_utils')
+    fu = importlib.import_module("helper.flops_utils")
     importlib.reload(fu)
+    monkeypatch.setattr(fu, "_get_flops", lambda *a, **k: 0, raising=False)
     flops = fu.get_flops_reliable(model, imgsz=8)
     assert flops > 0
 

--- a/tests/test_generate_mask_no_baseline.py
+++ b/tests/test_generate_mask_no_baseline.py
@@ -16,9 +16,10 @@ sys.path.insert(0, '{root.as_posix()}')
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
 utils.torch_utils = torch_utils
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 0
 up.YOLO = lambda *a, **k: None
 sys.modules['ultralytics'] = up
 sys.modules['ultralytics.utils'] = utils

--- a/tests/test_hsic_pipeline_auto_labels.py
+++ b/tests/test_hsic_pipeline_auto_labels.py
@@ -21,9 +21,10 @@ sys.modules['matplotlib.pyplot'] = plt
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda m: 0
 torch_utils.get_num_params = lambda m: 0
 utils.torch_utils = torch_utils
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda m: 0
 up.utils = utils
 sys.modules['ultralytics'] = up
 sys.modules['ultralytics.utils'] = utils

--- a/tests/test_initial_stats_reset.py
+++ b/tests/test_initial_stats_reset.py
@@ -11,8 +11,9 @@ sys.modules['torch.nn'] = types.ModuleType('torch.nn')
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda m: 0
 torch_utils.get_num_params = lambda m: 0
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda m: 0
 utils.torch_utils = torch_utils
 up.utils = utils
 up.YOLO = lambda *a, **k: types.SimpleNamespace(model=object())

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -9,8 +9,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 0
 utils.torch_utils = torch_utils
 up.YOLO = lambda *a, **k: None
 sys.modules['ultralytics'] = up

--- a/tests/test_main_help.py
+++ b/tests/test_main_help.py
@@ -16,8 +16,9 @@ def test_main_help_shows_options(capsys, monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: None
@@ -56,8 +57,9 @@ def test_device_argument_passed(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: None

--- a/tests/test_metrics_csv.py
+++ b/tests/test_metrics_csv.py
@@ -25,8 +25,9 @@ up = types.ModuleType('ultralytics')
 up.YOLO = lambda *a, **k: dummy
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 100
 torch_utils.get_num_params = lambda *a, **k: 200
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 100
 utils.torch_utils = torch_utils
 up.utils = utils
 
@@ -37,7 +38,7 @@ sys.modules['ultralytics.utils.torch_utils'] = torch_utils
 import main
 import pipeline.pruning_pipeline as pp
 pp.YOLO = up.YOLO
-pp.get_flops_reliable = torch_utils.get_flops
+pp.get_flops_reliable = fu.get_flops_reliable
 pp.get_num_params_reliable = torch_utils.get_num_params
 hsic_mod = types.ModuleType('prune_methods.depgraph_hsic')
 class DummyMethod:  # pragma: no cover - placeholder

--- a/tests/test_monitor_step.py
+++ b/tests/test_monitor_step.py
@@ -74,9 +74,10 @@ def test_monitor_metrics_recorded(monkeypatch, tmp_path):
     up.YOLO = lambda *a, **k: dummy
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 10
     torch_utils.get_num_params = lambda *a, **k: 20
     utils.torch_utils = torch_utils
+    from helper import flops_utils as fu
+    fu.get_flops_reliable = lambda *a, **k: 10
     up.utils = utils
 
     monkeypatch.setitem(sys.modules, 'ultralytics', up)
@@ -86,8 +87,8 @@ def test_monitor_metrics_recorded(monkeypatch, tmp_path):
     import main
     import pipeline.pruning_pipeline as pp
     monkeypatch.setattr(pp, 'YOLO', up.YOLO, raising=False)
-    monkeypatch.setattr(pp, 'get_flops', torch_utils.get_flops, raising=False)
-    monkeypatch.setattr(pp, 'get_num_params', torch_utils.get_num_params, raising=False)
+    monkeypatch.setattr(pp, 'get_flops_reliable', fu.get_flops_reliable, raising=False)
+    monkeypatch.setattr(pp, 'get_num_params_reliable', torch_utils.get_num_params, raising=False)
 
     monkeypatch.setattr(mc, 'GPUMetric', DummyGPU)
     monkeypatch.setattr(mc, 'MemoryMetric', DummyMemory)

--- a/tests/test_pipeline2_depgraph_random.py
+++ b/tests/test_pipeline2_depgraph_random.py
@@ -36,8 +36,9 @@ def setup(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     tu = types.ModuleType('ultralytics.utils.torch_utils')
-    tu.get_flops = lambda *a, **k: 0
     tu.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = tu
 
     class DummyYOLO:

--- a/tests/test_pipeline2_device_sync.py
+++ b/tests/test_pipeline2_device_sync.py
@@ -24,8 +24,9 @@ def setup_modules(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
 
     class DummyModel:

--- a/tests/test_pipeline2_generate_mask_loader.py
+++ b/tests/test_pipeline2_generate_mask_loader.py
@@ -9,8 +9,9 @@ def test_pipeline2_generate_mask_with_loader(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: types.SimpleNamespace(

--- a/tests/test_pipeline2_refresh.py
+++ b/tests/test_pipeline2_refresh.py
@@ -13,8 +13,9 @@ def test_apply_pruning_uses_method(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: None

--- a/tests/test_pipeline_imports.py
+++ b/tests/test_pipeline_imports.py
@@ -13,8 +13,9 @@ def test_step_imports_via_pipeline():
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: None

--- a/tests/test_pipeline_inplace_layer_change.py
+++ b/tests/test_pipeline_inplace_layer_change.py
@@ -66,9 +66,10 @@ class DummyYOLO:
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
 utils.torch_utils = torch_utils
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 0
 up.utils = utils
 up.YOLO = lambda *a, **k: DummyYOLO()
 sys.modules['ultralytics'] = up

--- a/tests/test_pipeline_loader.py
+++ b/tests/test_pipeline_loader.py
@@ -7,8 +7,9 @@ def setup(monkeypatch, loader):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
 
     class DummyYOLO:

--- a/tests/test_pipeline_remove_reparam.py
+++ b/tests/test_pipeline_remove_reparam.py
@@ -52,9 +52,10 @@ class DummyYOLO:
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
-torch_utils.get_num_params = lambda *a, **k: 0
-utils.torch_utils = torch_utils
+    torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    fu.get_flops_reliable = lambda *a, **k: 0
+    utils.torch_utils = torch_utils
 up.utils = utils
 up.YOLO = lambda *a, **k: DummyYOLO()
 sys.modules['ultralytics'] = up

--- a/tests/test_pretrain_callback_cleanup.py
+++ b/tests/test_pretrain_callback_cleanup.py
@@ -11,8 +11,9 @@ def test_pretrain_unregisters_callback_on_error(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
 
     class DummyYOLO:

--- a/tests/test_pruning_method_model_update.py
+++ b/tests/test_pruning_method_model_update.py
@@ -10,8 +10,9 @@ import torch  # noqa: F401
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 0
 utils.torch_utils = torch_utils
 
 class DummyYOLO:

--- a/tests/test_pruning_method_preserve_records.py
+++ b/tests/test_pruning_method_preserve_records.py
@@ -10,8 +10,9 @@ import torch  # noqa: F401
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda *a, **k: 0
 utils.torch_utils = torch_utils
 
 class DummyYOLO:

--- a/tests/test_pruning_pipeline2_model_update.py
+++ b/tests/test_pruning_pipeline2_model_update.py
@@ -13,8 +13,9 @@ def test_pruning_pipeline2_model_updated_after_training(monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
 
     class DummyYOLO:

--- a/tests/test_resume_flag.py
+++ b/tests/test_resume_flag.py
@@ -14,8 +14,9 @@ def test_resume_skipped_when_best_only(tmp_path, monkeypatch):
     up = types.ModuleType('ultralytics')
     utils = types.ModuleType('ultralytics.utils')
     torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-    torch_utils.get_flops = lambda *a, **k: 0
     torch_utils.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
     utils.torch_utils = torch_utils
     up.utils = utils
     up.YOLO = lambda *a, **k: None

--- a/tests/test_reuse_baseline.py
+++ b/tests/test_reuse_baseline.py
@@ -11,7 +11,6 @@ sys.modules['torch.nn'] = types.ModuleType('torch.nn')
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda *a, **k: 0
 torch_utils.get_num_params = lambda *a, **k: 0
 utils.torch_utils = torch_utils
 up.utils = utils
@@ -72,6 +71,8 @@ class DummyMgr:
 
 def test_baseline_reused_when_available(monkeypatch, tmp_path):
     calls = []
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
 
     def fake_exec(model, data, method_cls, ratio, cfg, workdir, **kw):
         calls.append(str(model))

--- a/tests/test_train_step_auto_analyze.py
+++ b/tests/test_train_step_auto_analyze.py
@@ -70,8 +70,9 @@ class DummyYOLO:
 up = types.ModuleType('ultralytics')
 utils = types.ModuleType('ultralytics.utils')
 torch_utils = types.ModuleType('ultralytics.utils.torch_utils')
-torch_utils.get_flops = lambda m: 0
 torch_utils.get_num_params = lambda m: 0
+from helper import flops_utils as fu
+fu.get_flops_reliable = lambda m: 0
 utils.torch_utils = torch_utils
 up.utils = utils
 up.YOLO = lambda *a, **k: DummyYOLO()


### PR DESCRIPTION
## Summary
- patch helper.flops_utils.get_flops_reliable instead of ultralytics.get_flops in tests
- adapt flops_utils fallback test
- update related stubs

## Testing
- `pytest -q` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_b_685939fbfa148324a517d9c8a2777b96