### PR TITLE
Fix logging import typo

### DIFF
--- a/helper/logger.py
+++ b/helper/logger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from contextlib import contextmanager
-from typing import Optional, callable
+from typing import Optional, Callable
 
 
 # ------------------------------------------------------------------
@@ -106,7 +106,7 @@ def get_logger(
 
 
 @contextmanager
-def timed_step(logger: "Logger", title: str, recover: Optional[callable] = None):
+def timed_step(logger: "Logger", title: str, recover: Optional[Callable[[], None]] = None):
     """Context manager to log the duration of *title* step.
 
     Example


### PR DESCRIPTION
## Summary
- fix ImportError by importing `Callable` instead of `callable`
- update `timed_step` annotation to use `Callable[[], None]`

## Testing
- `pytest -q` *(fails: Missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68599ad163a08324ae1b27e186cdd3d5