### PR TITLE
Use manual FLOP calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,10 @@ pip install scikit-learn
 
 ### FLOP statistics
 
-FLOP counting relies on the optional `ultralytics-thop` package, which is **not**
-included in `requirements.txt`. Without it, functions such as `get_flops`
-return ``0`` and the pruning pipeline logs a warning:
-
-```
-FLOPs reported as 0; verify that 'ultralytics-thop' is installed
-```
-
-Install ``ultralytics-thop`` separately if you require accurate FLOP metrics:
-
-```bash
-pip install ultralytics-thop
-```
+FLOP statistics are computed using a built-in manual method. Earlier versions
+relied on the optional `ultralytics-thop` package, but this dependency has been
+removed. The manual calculation works without extra packages, though the result
+may be slightly less accurate than dedicated profiling tools.
 
 ## Usage
 

--- a/helper/flops_utils.py
+++ b/helper/flops_utils.py
@@ -12,11 +12,9 @@ except Exception:  # pragma: no cover - torch may be missing
 
 try:
     from ultralytics.utils.torch_utils import (
-        get_flops as _get_flops,
         get_num_params as _get_num_params,
     )  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
-    _get_flops = None  # type: ignore
     _get_num_params = None  # type: ignore
 
 
@@ -85,16 +83,8 @@ def calculate_flops_manual(model: Any, imgsz: int | Iterable[int] = 640) -> floa
 
 
 def get_flops_reliable(model: Any, imgsz: int | Iterable[int] = 640) -> float:
-    """Return FLOPs using ``ultralytics`` if available, else manual calculation."""
-    flops = 0.0
-    if _get_flops is not None:
-        try:
-            flops = float(_get_flops(model, imgsz=imgsz))
-        except Exception:  # pragma: no cover - best effort
-            flops = 0.0
-    if not flops:
-        flops = calculate_flops_manual(model, imgsz)
-    return flops
+    """Return FLOPs using the built-in manual calculation."""
+    return calculate_flops_manual(model, imgsz)
 
 
 def get_num_params_reliable(model: Any) -> int:

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -88,7 +88,7 @@ class PruningPipeline(BasePruningPipeline):
         flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
+                "FLOPs reported as 0; fallback calculation may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
@@ -190,7 +190,7 @@ class PruningPipeline(BasePruningPipeline):
         flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
+                "FLOPs reported as 0; fallback calculation may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -113,7 +113,7 @@ class PruningPipeline2(BasePruningPipeline):
         flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
+                "FLOPs reported as 0; fallback calculation may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)
@@ -257,7 +257,7 @@ class PruningPipeline2(BasePruningPipeline):
         flops = get_flops_reliable(self.model.model)
         if flops == 0:
             self.logger.warning(
-                "FLOPs reported as 0; verify that 'ultralytics-thop' is installed or fallback may be inaccurate"
+                "FLOPs reported as 0; fallback calculation may be inaccurate"
             )
         filters = count_filters(self.model.model)
         size_mb = model_size_mb(self.model.model)

--- a/tests/test_flops_utils.py
+++ b/tests/test_flops_utils.py
@@ -18,7 +18,6 @@ def test_get_flops_reliable_fallback(monkeypatch):
     model = nn.Sequential(nn.Conv2d(3, 8, 1))
     fu = importlib.import_module("helper.flops_utils")
     importlib.reload(fu)
-    monkeypatch.setattr(fu, "_get_flops", lambda *a, **k: 0, raising=False)
     flops = fu.get_flops_reliable(model, imgsz=8)
     assert flops > 0
 
@@ -56,8 +55,6 @@ def test_calculate_flops_manual_respects_device(monkeypatch):
     model = nn.Sequential(nn.Conv2d(3, 8, 1))
     device = next(model.parameters()).device
 
-    monkeypatch.setattr(fu, "_get_flops", lambda *a, **k: 0, raising=False)
-
     recorded = {}
     orig_zeros = torch.zeros
 
@@ -91,8 +88,6 @@ def test_calculate_flops_manual_handles_errors(monkeypatch):
             return x
 
     model = BadModel()
-
-    monkeypatch.setattr(fu, "_get_flops", lambda *a, **k: 0, raising=False)
 
     flops = fu.calculate_flops_manual(model, imgsz=8)
 


### PR DESCRIPTION
## Summary
- calculate FLOPs manually without ultralytics
- adjust pipeline warning text
- update docs on FLOP stats
- update tests for manual method

## Testing
- `pytest tests/test_flops_utils.py -vv`
- `pytest -q` *(fails: 12 failed, 16 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6859aa02f8bc83248ff26e6f8a4e0915