### PR TITLE
Fix GroupNorm pruner example input

### DIFF
--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -362,7 +362,9 @@ class DepgraphHSICMethod(BasePruningMethod):
         except Exception:
             device = torch.device("cpu")
 
-            example_inputs = tuple(t.to(device) if torch.is_tensor(t) else t for t in self._inputs_tuple())
+        example_inputs = tuple(
+            t.to(device) if torch.is_tensor(t) else t for t in self._inputs_tuple()
+        )
         
         # Use the model instance directly
         model_to_analyze = self.model

--- a/tests/test_hsic_groupnorm_no_unbound.py
+++ b/tests/test_hsic_groupnorm_no_unbound.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_groupnorm_pruner_no_unbound(tmp_path):
+    code = f"""
+import torch
+from prune_methods.depgraph_hsic import DepgraphHSICMethod
+
+model = torch.nn.Sequential(
+    torch.nn.Conv2d(3, 4, 3),
+    torch.nn.ReLU(),
+    torch.nn.Conv2d(4, 8, 3),
+    torch.nn.ReLU(),
+)
+method = DepgraphHSICMethod(model, workdir='{tmp_path}')
+method.example_inputs = torch.randn(1, 3, 8, 8)
+method.analyze_model()
+method.generate_pruning_mask(0.5)
+print('ok')
+"""
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert 'ok' in proc.stdout


### PR DESCRIPTION
## Summary
- fix `example_inputs` initialization in `_use_group_norm_pruner`
- test that group norm pruning doesn't raise `UnboundLocalError`

## Testing
- `pytest -q tests/test_hsic_groupnorm_no_unbound.py`

------
https://chatgpt.com/codex/tasks/task_b_6859b9a59fe0832484f4c1a8a2971a53