### PR TITLE
Fix flops=0 after pruning

### DIFF
--- a/helper/flops_utils.py
+++ b/helper/flops_utils.py
@@ -13,9 +13,11 @@ except Exception:  # pragma: no cover - torch may be missing
 try:
     from ultralytics.utils.torch_utils import (
         get_num_params as _get_num_params,
+        get_flops_with_torch_profiler,
     )  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     _get_num_params = None  # type: ignore
+    get_flops_with_torch_profiler = None  # type: ignore
 
 
 def _conv_hook(module: Any, _inp: Iterable[Any], output: Any, totals: list[int]) -> None:
@@ -83,8 +85,14 @@ def calculate_flops_manual(model: Any, imgsz: int | Iterable[int] = 640) -> floa
 
 
 def get_flops_reliable(model: Any, imgsz: int | Iterable[int] = 640) -> float:
-    """Return FLOPs using the built-in manual calculation."""
-    return calculate_flops_manual(model, imgsz)
+    """Return FLOPs using manual calculation with a torch profiler fallback."""
+    flops = calculate_flops_manual(model, imgsz)
+    if flops == 0 and get_flops_with_torch_profiler is not None:
+        try:  # pragma: no cover - best effort
+            flops = float(get_flops_with_torch_profiler(model, imgsz))
+        except Exception:
+            flops = 0.0
+    return flops
 
 
 def get_num_params_reliable(model: Any) -> int:


### PR DESCRIPTION
## Summary
- add torch profiler fallback when manual FLOPs calc fails

## Testing
- `pytest -q` *(fails: test_hsic_insufficient_labels_error, test_hsic_label_mismatch, test_hsic_minimum_pruning_ratio, test_hsic_missing_layer_warning, test_hsic_pipeline_auto_labels, test_hsic_rebuild_on_missing_layer, test_initial_stats_reset, test_logger_file, test_main_help, test_monitor_step, test_pipeline2_depgraph_random, test_pipeline2_refresh, test_pipeline_imports, test_pipeline_inplace_layer_change, test_pipeline_remove_reparam, test_remove_reparam, test_resume_flag, test_snapshot_save, test_train_step_warning)*

------
https://chatgpt.com/codex/tasks/task_b_6859b87171148324a3206467dfc5436e