### PR TITLE
Enable debug logging by default

### DIFF
--- a/helper/logger.py
+++ b/helper/logger.py
@@ -50,7 +50,9 @@ class Logger:
 
     def __init__(self, name: str = "pruning", log_file: Optional[str] = None) -> None:
         self.logger = logging.getLogger(name)
-        self.logger.setLevel(logging.INFO)
+        # Default to DEBUG level so detailed information is captured unless
+        # overridden by ``set_level`` or ``get_logger`` parameters.
+        self.logger.setLevel(logging.DEBUG)
         # Prevent messages from propagating to ancestor loggers
         # which can lead to duplicate entries if the root logger is configured.
         self.logger.propagate = False
@@ -105,7 +107,7 @@ def add_file_handler(logger: Logger, log_file: str) -> None:
 
 def get_logger(
     name: str = "pruning",
-    level: int = logging.INFO,
+    level: int = logging.DEBUG,
     log_file: Optional[str] = None,
 ) -> Logger:
     """Return a :class:`Logger` configured with ``name`` and ``level``."""

--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -168,7 +168,15 @@ class PruningPipeline(BasePruningPipeline):
     def apply_pruning(self, rebuild: bool = False) -> None:
         """Apply the generated pruning mask."""
         if self.pruning_method is not None:
-            self.pruning_method.apply_pruning(rebuild=rebuild)
+            import inspect
+            try:
+                sig = inspect.signature(self.pruning_method.apply_pruning)
+                if 'rebuild' in sig.parameters:
+                    self.pruning_method.apply_pruning(rebuild=rebuild)
+                else:
+                    self.pruning_method.apply_pruning()
+            except (ValueError, TypeError):  # pragma: no cover - fallback
+                self.pruning_method.apply_pruning(rebuild=rebuild)
 
     def reconfigure_model(self, output_path: str | None = None) -> None:
         """Reconfigure the model after pruning."""

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -240,7 +240,15 @@ class PruningPipeline2(BasePruningPipeline):
     def apply_pruning(self, rebuild: bool = False) -> None:
         if self.pruning_method is None:
             raise ValueError("No pruning method set")
-        self.pruning_method.apply_pruning(rebuild=rebuild)
+        import inspect
+        try:
+            sig = inspect.signature(self.pruning_method.apply_pruning)
+            if 'rebuild' in sig.parameters:
+                self.pruning_method.apply_pruning(rebuild=rebuild)
+            else:
+                self.pruning_method.apply_pruning()
+        except (ValueError, TypeError):  # pragma: no cover - fallback
+            self.pruning_method.apply_pruning(rebuild=rebuild)
 
     def reconfigure_model(self, output_path: str | Path | None = None) -> None:
         # DepGraph methods don't require reconfiguration


### PR DESCRIPTION
## Summary
- default to DEBUG logging in helper.logger
- ignore `--debug` flag and log at DEBUG level in all entry points
- ensure pipelines call pruning methods with or without `rebuild` parameter

## Testing
- `pytest -q` *(fails: 16 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6859b97d968483249c00496a083f70d8