### PR TITLE
Fix FLOPs calc when forward fails

### DIFF
--- a/helper/flops_utils.py
+++ b/helper/flops_utils.py
@@ -74,9 +74,10 @@ def calculate_flops_manual(model: Any, imgsz: int | Iterable[int] = 640) -> floa
         with torch.no_grad():
             model(dummy)
     except Exception:
+        # forward failed; return partial FLOPs collected so far
         for h in hooks:
             h.remove()
-        return 0.0
+        return totals[0] * 2 / 1e9
     for h in hooks:
         h.remove()
     return totals[0] * 2 / 1e9

--- a/tests/test_flops_utils.py
+++ b/tests/test_flops_utils.py
@@ -91,4 +91,4 @@ def test_calculate_flops_manual_handles_errors(monkeypatch):
 
     flops = fu.calculate_flops_manual(model, imgsz=8)
 
-    assert flops == 0.0
+    assert flops > 0


### PR DESCRIPTION
## Summary
- tolerate forward errors in `calculate_flops_manual` and return partial FLOPs instead of zero
- update unit test to expect a non-zero value

## Testing
- `pytest -q tests/test_flops_utils.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_6859b9be1bf0832490843958015a0a08