### PR TITLE
Suppress verbose metrics output

### DIFF
--- a/pipeline/pruning_pipeline.py
+++ b/pipeline/pruning_pipeline.py
@@ -148,8 +148,8 @@ class PruningPipeline(BasePruningPipeline):
                         self.logger.debug("reanalyzed pruning method model")
                 except Exception:  # pragma: no cover - best effort
                     self.logger.exception("failed to reanalyze model")
-        self.logger.debug(metrics)
         if metrics:
+            self.logger.debug("Training summary: %s", format_training_summary(metrics))
             self.logger.info("Training summary: %s", format_training_summary(metrics))
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["pretrain"] = metrics
@@ -242,8 +242,8 @@ class PruningPipeline(BasePruningPipeline):
                         self.logger.debug("reanalyzed pruning method model")
                 except Exception:  # pragma: no cover - best effort
                     self.logger.exception("failed to reanalyze model")
-        self.logger.debug(metrics)
         if metrics:
+            self.logger.debug("Training summary: %s", format_training_summary(metrics))
             self.logger.info("Training summary: %s", format_training_summary(metrics))
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["finetune"] = metrics

--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -300,8 +300,8 @@ class PruningPipeline2(BasePruningPipeline):
                 self._sync_pruning_method(reanalyze=model_changed)
             except Exception:
                 self.logger.exception("failed to sync pruning method")
-        self.logger.debug(metrics)
         if metrics:
+            self.logger.debug("Training summary: %s", format_training_summary(metrics))
             self.logger.info("Training summary: %s", format_training_summary(metrics))
         self.metrics_mgr.record_training(metrics or {})
         self.metrics["finetune"] = metrics or {}


### PR DESCRIPTION
## Summary
- avoid logging large `curves_results` arrays by printing only the training summary

## Testing
- `pytest -q` *(fails: Missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685a3971ffe083249ca2d240dd6e78a7