### PR TITLE
Fix HSIC dataloader handling in pipeline2

### DIFF
--- a/pipeline/pruning_pipeline_2.py
+++ b/pipeline/pruning_pipeline_2.py
@@ -190,12 +190,19 @@ class PruningPipeline2(BasePruningPipeline):
         self.pruning_method.analyze_model()
         if dataloader is None:
             dataloader = getattr(getattr(self.model, "trainer", None), "val_loader", None)
+
+        if isinstance(self.pruning_method, DepgraphHSICMethod):
             if dataloader is None:
                 raise ValueError("dataloader is required")
-        self.pruning_method.generate_pruning_mask(
-            ratio,
-            dataloader=dataloader,
-        )
+            self.pruning_method.generate_pruning_mask(
+                ratio,
+                dataloader=dataloader,
+            )
+        else:
+            self.pruning_method.generate_pruning_mask(
+                ratio,
+                dataloader=dataloader,
+            )
         plan = getattr(self.pruning_method, "pruning_plan", [])
         channels = len(plan)
         total = sum(

--- a/tests/test_pipeline2_depgraph_random.py
+++ b/tests/test_pipeline2_depgraph_random.py
@@ -78,5 +78,4 @@ def test_pipeline2_depgraph_and_random_methods(monkeypatch):
         pipeline = pp.PruningPipeline2('m', 'd', pruning_method=method)
         pipeline.load_model()
         pipeline.analyze_structure()
-        with pytest.raises(ValueError):
-            pipeline.generate_pruning_mask(0.5)
+        pipeline.generate_pruning_mask(0.5)

--- a/tests/test_pipeline2_hsic_loader_error.py
+++ b/tests/test_pipeline2_hsic_loader_error.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def test_pipeline2_hsic_requires_loader(monkeypatch):
+    up = types.ModuleType('ultralytics')
+    utils = types.ModuleType('ultralytics.utils')
+    tu = types.ModuleType('ultralytics.utils.torch_utils')
+    tu.get_num_params = lambda *a, **k: 0
+    from helper import flops_utils as fu
+    monkeypatch.setattr(fu, "get_flops_reliable", lambda *a, **k: 0, raising=False)
+    utils.torch_utils = tu
+
+    class DummyYOLO:
+        def __init__(self):
+            self.model = types.SimpleNamespace()
+            self.callbacks = {}
+            self.trainer = types.SimpleNamespace(val_loader=None)
+        def add_callback(self, event, cb):
+            pass
+
+    up.utils = utils
+    up.YOLO = lambda *a, **k: DummyYOLO()
+    monkeypatch.setitem(sys.modules, 'ultralytics', up)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils', utils)
+    monkeypatch.setitem(sys.modules, 'ultralytics.utils.torch_utils', tu)
+
+    hsic_mod = types.ModuleType('prune_methods.depgraph_hsic')
+
+    class DummyMethod:
+        def __init__(self, model=None, **kw):
+            self.model = model
+            self.called = False
+        def analyze_model(self):
+            pass
+        def generate_pruning_mask(self, ratio, dataloader=None):
+            self.called = True
+
+    hsic_mod.DepgraphHSICMethod = DummyMethod
+    monkeypatch.setitem(sys.modules, 'prune_methods.depgraph_hsic', hsic_mod)
+
+    pp = importlib.import_module('pipeline.pruning_pipeline_2')
+    importlib.reload(pp)
+
+    pipeline = pp.PruningPipeline2('m', 'd', pruning_method=DummyMethod(None))
+    pipeline.load_model()
+
+    with pytest.raises(ValueError):
+        pipeline.generate_pruning_mask(0.5)
+    assert not pipeline.pruning_method.called


### PR DESCRIPTION
## Summary
- ensure HSIC methods always receive a dataloader
- relax dataloader requirement for other methods
- add regression tests for missing dataloader handling

## Testing
- `pytest tests/test_pipeline2_generate_mask_loader.py::test_pipeline2_generate_mask_with_loader tests/test_pipeline_loader.py::test_loader_passed tests/test_pipeline2_depgraph_random.py::test_pipeline2_depgraph_and_random_methods tests/test_pipeline2_hsic_loader_error.py::test_pipeline2_hsic_requires_loader -q`

------
https://chatgpt.com/codex/tasks/task_b_685a5d38ee008324aeac745b0e584e20