### PR TITLE
Fix activation hook annotation

### DIFF
--- a/prune_methods/depgraph_hsic_2.py
+++ b/prune_methods/depgraph_hsic_2.py
@@ -122,7 +122,7 @@ class DepGraphHSICMethod2(BasePruningMethod):
     # ------------------------------------------------------------------
     # Activation collection
     # ------------------------------------------------------------------
-    def _register_activation_hooks(self) -> None -> None:
+    def _register_activation_hooks(self) -> None:
         def make_hook(idx: int):
             def hook(_mod: nn.Module, _inp: Tuple[torch.Tensor], out: torch.Tensor) -> None:
                 shp = self.layer_shapes.setdefault(idx, out.shape[2:])


### PR DESCRIPTION
## Summary
- fix the `_register_activation_hooks` signature

## Testing
- `python -m py_compile prune_methods/depgraph_hsic_2.py`


------
https://chatgpt.com/codex/tasks/task_b_685aeb1971788324a62bf452fb0895ab