### PR TITLE
Add example_inputs parameter to pruning base

### DIFF
--- a/prune_methods/base.py
+++ b/prune_methods/base.py
@@ -28,7 +28,12 @@ class BasePruningMethod(abc.ABC):
 
     requires_reconfiguration: bool = True
 
-    def __init__(self, model: Any, workdir: str | Path = "runs/pruning") -> None:
+    def __init__(
+        self,
+        model: Any,
+        workdir: str | Path = "runs/pruning",
+        example_inputs: torch.Tensor | tuple | None = None,
+    ) -> None:
         self.model = model
         self.workdir = Path(workdir)
         self.workdir.mkdir(parents=True, exist_ok=True)
@@ -36,6 +41,7 @@ class BasePruningMethod(abc.ABC):
         self.pruned_stats: Dict[str, float] = {}
         self.logger: Logger = get_logger()
         self.masks: List[torch.Tensor] = []
+        self.example_inputs = example_inputs or torch.randn(1, 3, 640, 640)
 
     # ------------------------------------------------------------------
     # Core pruning steps to be implemented by subclasses

--- a/prune_methods/depgraph_hsic.py
+++ b/prune_methods/depgraph_hsic.py
@@ -54,12 +54,19 @@ class DepgraphHSICMethod(BasePruningMethod):
 
     requires_reconfiguration = False
 
-    def __init__(self, model: Any, workdir: str = "runs/pruning", gamma: float = 1.0, num_modules: int = 10, pruning_scope: str = "backbone") -> None:
-        super().__init__(model, workdir)
+    def __init__(
+        self,
+        model: Any,
+        workdir: str = "runs/pruning",
+        gamma: float = 1.0,
+        num_modules: int = 10,
+        pruning_scope: str = "backbone",
+        example_inputs: torch.Tensor | tuple | None = None,
+    ) -> None:
+        super().__init__(model, workdir, example_inputs)
         self.gamma = gamma
         self.num_modules = num_modules
         self.pruning_scope = pruning_scope
-        self.example_inputs = torch.randn(1, 3, 640, 640)
         self.DG = None
         self._dg_model = None
         self.handles: List[torch.utils.hooks.RemovableHandle] = []

--- a/prune_methods/depgraph_hsic_2.py
+++ b/prune_methods/depgraph_hsic_2.py
@@ -56,16 +56,15 @@ class DepGraphHSICMethod2(BasePruningMethod):
         alpha: float = 0.5,
         sub_group_clusters: int = 3,
         iterations: int = 1,
-        example_inputs: Optional[torch.Tensor] = None,
+        example_inputs: torch.Tensor | tuple | None = None,
     ) -> None:
-        super().__init__(model, workdir)
+        super().__init__(model, workdir, example_inputs)
         self.sigma = sigma
         self.max_samples = max_samples
         self.seed = seed
         self.alpha = float(alpha)
         self.sub_group_clusters = sub_group_clusters
         self.iterations = iterations
-        self.example_inputs = example_inputs or torch.randn(1, 3, 640, 640)
 
         # Internal state
         self.DG: Optional[tp.DependencyGraph] = None

--- a/prune_methods/depgraph_pruning.py
+++ b/prune_methods/depgraph_pruning.py
@@ -12,9 +12,13 @@ class DepgraphMethod(BasePruningMethod):
 
     requires_reconfiguration = False
 
-    def __init__(self, model: Any, workdir: str = "runs/pruning") -> None:
-        super().__init__(model, workdir)
-        self.example_inputs = torch.randn(1, 3, 640, 640)
+    def __init__(
+        self,
+        model: Any,
+        workdir: str = "runs/pruning",
+        example_inputs: torch.Tensor | tuple | None = None,
+    ) -> None:
+        super().__init__(model, workdir, example_inputs)
         self.pruner: Any | None = None
 
     def analyze_model(self) -> None:

--- a/prune_methods/isomorphic_pruning.py
+++ b/prune_methods/isomorphic_pruning.py
@@ -18,9 +18,14 @@ class IsomorphicMethod(BasePruningMethod):
 
     requires_reconfiguration = False
 
-    def __init__(self, model: Any, workdir: str = "runs/pruning", round_to: int | None = None) -> None:
-        super().__init__(model, workdir)
-        self.example_inputs = torch.randn(1, 3, 640, 640)
+    def __init__(
+        self,
+        model: Any,
+        workdir: str = "runs/pruning",
+        round_to: int | None = None,
+        example_inputs: torch.Tensor | tuple | None = None,
+    ) -> None:
+        super().__init__(model, workdir, example_inputs)
         self.round_to = round_to
         self.pruner = None
 

--- a/prune_methods/torch_pruning_simple.py
+++ b/prune_methods/torch_pruning_simple.py
@@ -13,9 +13,13 @@ class TorchRandomMethod(BasePruningMethod):
 
     requires_reconfiguration = False
 
-    def __init__(self, model: Any, workdir: str = "runs/pruning") -> None:
-        super().__init__(model, workdir)
-        self.example_inputs = torch.randn(1, 3, 640, 640)
+    def __init__(
+        self,
+        model: Any,
+        workdir: str = "runs/pruning",
+        example_inputs: torch.Tensor | tuple | None = None,
+    ) -> None:
+        super().__init__(model, workdir, example_inputs)
         self.pruner: Any | None = None
 
     def analyze_model(self) -> None:


### PR DESCRIPTION
## Summary
- extend `BasePruningMethod.__init__` with `example_inputs` parameter
- pass `example_inputs` through in subclasses

## Testing
- `pytest tests/test_inputs_tuple.py::test_dependency_graph_builds_with_list_inputs -vv` *(fails: AttributeError: 'Sequential' object has no attribute 'model')*

------
https://chatgpt.com/codex/tasks/task_b_685aeb4eb5dc83248b2f9d936a52ed0a