### PR TITLE
Add import test for prune methods

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,14 @@
+import prune_methods
+
+class DummyYOLO:
+    def __init__(self):
+        self.model = []
+
+def test_all_prune_methods_instantiable(tmp_path):
+    yolo = DummyYOLO()
+    for name in prune_methods.__all__:
+        if name == "BasePruningMethod":
+            continue
+        cls = getattr(prune_methods, name)
+        instance = cls(yolo, tmp_path)
+        assert isinstance(instance, cls)


### PR DESCRIPTION
## Summary
- add a lightweight test ensuring all pruning classes instantiate with a dummy YOLO model

## Testing
- `pytest -q tests/test_imports.py`

------
https://chatgpt.com/codex/tasks/task_b_685af0363d14832494526372f393df20