### PR TITLE
Ensure FLOPs calc handles forward failures

### DIFF
--- a/tests/test_flops_utils.py
+++ b/tests/test_flops_utils.py
@@ -1,6 +1,7 @@
 import importlib
 import types
 import sys
+import pytest
 
 
 def test_calculate_flops_manual_no_torch(monkeypatch):
@@ -89,6 +90,5 @@ def test_calculate_flops_manual_handles_errors(monkeypatch):
 
     model = BadModel()
 
-    flops = fu.calculate_flops_manual(model, imgsz=8)
-
-    assert flops > 0
+    with pytest.raises(RuntimeError):
+        fu.calculate_flops_manual(model, imgsz=8)


### PR DESCRIPTION
## Summary
- raise an error if `calculate_flops_manual` forward pass fails
- log failure in `get_flops_reliable`
- expect an exception in `test_calculate_flops_manual_handles_errors`

## Testing
- `pytest tests/test_flops_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_b_685bb7c5f2ac832481f259740e9ceedb